### PR TITLE
feat: auto-categorise bills based on their title

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -39,6 +39,8 @@
 		<command>OCA\Cospend\Command\RepeatBills</command>
 		<command>OCA\Cospend\Command\ExportProject</command>
 		<command>OCA\Cospend\Command\DeleteBills</command>
+		<command>OCA\Cospend\Command\AutoCategorizeProject</command>
+		<command>OCA\Cospend\Command\AutoCategorizeAll</command>
 	</commands>
 	<activity>
 		<settings>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -196,5 +196,14 @@ return [
 		['name' => 'publicApi#publicEditCategory', 'url' => '/api/{apiVersion}/public/projects/{token}/{password}/category/{categoryId}', 'verb' => 'PUT', 'requirements' => $publicRequirements],
 		['name' => 'publicApi#publicSaveCategoryOrder', 'url' => '/api/{apiVersion}/public/projects/{token}/{password}/category-order', 'verb' => 'PUT', 'requirements' => $publicRequirements],
 		['name' => 'publicApi#publicDeleteCategory', 'url' => '/api/{apiVersion}/public/projects/{token}/{password}/category/{categoryId}', 'verb' => 'DELETE', 'requirements' => $publicRequirements],
+		// auto-categorisation mappings
+		['name' => 'api#getAutoCategoryMappings', 'url' => '/api/{apiVersion}/projects/{projectId}/auto-mappings', 'verb' => 'GET', 'requirements' => $requirements],
+		['name' => 'api#createAutoCategoryMapping', 'url' => '/api/{apiVersion}/projects/{projectId}/auto-mappings', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'api#editAutoCategoryMapping', 'url' => '/api/{apiVersion}/projects/{projectId}/auto-mappings/{mappingId}', 'verb' => 'PUT', 'requirements' => $requirements],
+		['name' => 'api#deleteAutoCategoryMapping', 'url' => '/api/{apiVersion}/projects/{projectId}/auto-mappings/{mappingId}', 'verb' => 'DELETE', 'requirements' => $requirements],
+		['name' => 'api#autoCategorizeProject', 'url' => '/api/{apiVersion}/projects/{projectId}/auto-categorize', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'api#autoCategorizeAll', 'url' => '/api/{apiVersion}/auto-categorize', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'api#copyAutoCategoryMappings', 'url' => '/api/{apiVersion}/projects/{projectId}/auto-mappings/copy-to/{targetProjectId}', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'api#importAutoCategoryMappings', 'url' => '/api/{apiVersion}/projects/{projectId}/auto-mappings/import-from/{sourceProjectId}', 'verb' => 'POST', 'requirements' => $requirements],
 	],
 ];

--- a/lib/Command/AutoCategorizeAll.php
+++ b/lib/Command/AutoCategorizeAll.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Cospend\Command;
+
+use OC\Core\Command\Base;
+use OCA\Cospend\Service\LocalProjectService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AutoCategorizeAll extends Base {
+
+	public function __construct(
+		private LocalProjectService $projectService,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this->setName('cospend:auto-categorize:all')
+			->setDescription('Auto-categorise uncategorised bills in all non-archived projects with auto-categorisation enabled');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		try {
+			$totalCount = $this->projectService->autoCategorizeAllBills();
+			$output->writeln("$totalCount bill(s) categorised across all projects");
+		} catch (\Exception $e) {
+			$output->writeln('<error>Failed to auto-categorise: ' . $e->getMessage() . '</error>');
+			return 1;
+		}
+		return 0;
+	}
+}

--- a/lib/Command/AutoCategorizeProject.php
+++ b/lib/Command/AutoCategorizeProject.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Cospend\Command;
+
+use OC\Core\Command\Base;
+use OCA\Cospend\Service\LocalProjectService;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AutoCategorizeProject extends Base {
+
+	public function __construct(
+		private LocalProjectService $projectService,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this->setName('cospend:auto-categorize:project')
+			->setDescription('Auto-categorise uncategorised bills in a project')
+			->addArgument(
+				'project_id',
+				InputArgument::REQUIRED,
+				'The id of the project'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$projectId = $input->getArgument('project_id');
+		try {
+			$count = $this->projectService->autoCategorizeProjectBills($projectId);
+			$output->writeln("$count bill(s) categorised in project $projectId");
+		} catch (\Exception $e) {
+			$output->writeln('<error>Failed to auto-categorise: ' . $e->getMessage() . '</error>');
+			return 1;
+		}
+		return 0;
+	}
+}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -51,6 +51,8 @@ use OCP\Share\IShare;
  * @psalm-import-type CospendPaymentMode from ResponseDefinitions
  * @psalm-import-type CospendCategory from ResponseDefinitions
  * @psalm-import-type CospendCurrency from ResponseDefinitions
+ * @psalm-import-type CospendAutoCategoryMapping from ResponseDefinitions
+ * @psalm-import-type CospendAutoCategoryMappingCopyResult from ResponseDefinitions
  * @psalm-import-type CospendUserShare from ResponseDefinitions
  * @psalm-import-type CospendPublicShare from ResponseDefinitions
  * @psalm-import-type CospendGroupShare from ResponseDefinitions
@@ -195,6 +197,7 @@ class ApiController extends OCSController {
 	 * @param string|null $categorySort
 	 * @param string|null $paymentModeSort
 	 * @param int|null $archivedTs
+	 * @param string|null $autoCategorization
 	 * @return DataResponse<Http::STATUS_OK, '', array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
 	 *
 	 * 200: The project was successfully update
@@ -208,11 +211,13 @@ class ApiController extends OCSController {
 		string $projectId, ?string $name = null,
 		?string $autoExport = null, ?string $currencyName = null, ?bool $deletionDisabled = null,
 		?string $categorySort = null, ?string $paymentModeSort = null, ?int $archivedTs = null,
+		?string $autoCategorization = null,
 	): DataResponse {
 		try {
 			$this->projectService->editProject(
 				$projectId, $name, null, $autoExport,
-				$currencyName, $deletionDisabled, $categorySort, $paymentModeSort, $archivedTs
+				$currencyName, $deletionDisabled, $categorySort, $paymentModeSort, $archivedTs,
+				$autoCategorization
 			);
 			return new DataResponse('');
 		} catch (ClientException $e) {
@@ -465,6 +470,7 @@ class ApiController extends OCSController {
 	 * @param string|null $comment
 	 * @param int|null $repeatFreq
 	 * @param int|null $deleted
+	 * @param bool $autoCategorise
 	 * @return DataResponse<Http::STATUS_OK, int, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
 	 * @throws DoesNotExistException
 	 * @throws Exception
@@ -480,12 +486,13 @@ class ApiController extends OCSController {
 		?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, ?int $repeatAllActive = null, ?string $repeatUntil = null,
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null, ?int $deleted = null,
+		bool $autoCategorise = true,
 	): DataResponse {
 		try {
 			$this->projectService->editBill(
 				$projectId, $billId, $date, $what, $payer, $payedFor,
 				$amount, $repeat, $paymentMode, $paymentModeId, $categoryId,
-				$repeatAllActive, $repeatUntil, $timestamp, $comment, $repeatFreq, $deleted, true
+				$repeatAllActive, $repeatUntil, $timestamp, $comment, $repeatFreq, $deleted, true, $autoCategorise
 			);
 			return new DataResponse($billId);
 		} catch (ClientException $e) {
@@ -646,6 +653,7 @@ class ApiController extends OCSController {
 	 * @param int|null $timestamp
 	 * @param string|null $comment
 	 * @param int|null $repeatFreq
+	 * @param bool $autoCategorise
 	 * @return DataResponse<Http::STATUS_OK, int, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
 	 * @throws Exception
 	 */
@@ -657,13 +665,13 @@ class ApiController extends OCSController {
 		string $projectId, ?string $date = null, ?string $what = null, ?int $payer = null, ?string $payedFor = null,
 		?float $amount = null, ?string $repeat = null, ?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, int $repeatAllActive = 0, ?string $repeatUntil = null, ?int $timestamp = null,
-		?string $comment = null, ?int $repeatFreq = null,
+		?string $comment = null, ?int $repeatFreq = null, bool $autoCategorise = true,
 	): DataResponse {
 		try {
 			$newBillId = $this->projectService->createBill(
 				$projectId, $date, $what, $payer, $payedFor, $amount,
 				$repeat, $paymentMode, $paymentModeId, $categoryId, $repeatAllActive,
-				$repeatUntil, $timestamp, $comment, $repeatFreq, 0, true
+				$repeatUntil, $timestamp, $comment, $repeatFreq, 0, true, $autoCategorise
 			);
 			return new DataResponse($newBillId);
 		} catch (ClientException $e) {
@@ -1104,6 +1112,215 @@ class ApiController extends OCSController {
 		try {
 			$this->projectService->deleteCategory($projectId, $categoryId);
 			return new DataResponse('');
+		} catch (ClientException $e) {
+			return $this->getResponseFromClientException($e);
+		}
+	}
+
+	/**
+	 * Get auto-category mappings for a project
+	 *
+	 * Viewer level is enough: mappings are applied client-side when typing a bill title,
+	 * so every user who can see the project needs to be able to read them.
+	 *
+	 * @param string $projectId
+	 * @return DataResponse<Http::STATUS_OK, list<CospendAutoCategoryMapping>, array{}>|DataResponse<Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
+	 * @throws Exception
+	 *
+	 * 200: The mappings were successfully fetched
+	 * 424: Failed to get the mappings
+	 */
+	#[NoAdminRequired]
+	#[CospendUserPermissions(minimumLevel: Application::ACCESS_LEVEL_VIEWER)]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Auto-categorisation'])]
+	public function getAutoCategoryMappings(string $projectId): DataResponse {
+		try {
+			$mappings = $this->localProjectService->getAutoCategoryMappings($projectId);
+			return new DataResponse($mappings);
+		} catch (ClientException $e) {
+			return $this->getResponseFromClientException($e);
+		}
+	}
+
+	/**
+	 * Create an auto-category mapping
+	 *
+	 * @param string $projectId
+	 * @param string $billTitle
+	 * @param int $categoryId
+	 * @return DataResponse<Http::STATUS_OK, int, array{}>|DataResponse<Http::STATUS_CONFLICT|Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
+	 * @throws Exception
+	 *
+	 * 200: The mapping was successfully created
+	 * 409: A mapping with this title already exists
+	 * 424: Failed to create the mapping
+	 */
+	#[NoAdminRequired]
+	#[CospendUserPermissions(minimumLevel: Application::ACCESS_LEVEL_MAINTAINER)]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Auto-categorisation'])]
+	public function createAutoCategoryMapping(string $projectId, string $billTitle, int $categoryId): DataResponse {
+		try {
+			$insertedId = $this->localProjectService->createAutoCategoryMapping($projectId, $billTitle, $categoryId);
+			return new DataResponse($insertedId);
+		} catch (CospendBasicException $e) {
+			return new DataResponse($e->data, Http::STATUS_CONFLICT);
+		} catch (ClientException $e) {
+			return $this->getResponseFromClientException($e);
+		}
+	}
+
+	/**
+	 * Edit an auto-category mapping
+	 *
+	 * @param string $projectId
+	 * @param int $mappingId
+	 * @param string $billTitle
+	 * @param int $categoryId
+	 * @return DataResponse<Http::STATUS_OK, CospendAutoCategoryMapping, array{}>|DataResponse<Http::STATUS_NOT_FOUND|Http::STATUS_CONFLICT|Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
+	 *
+	 * 200: The mapping was successfully edited
+	 * 404: The mapping was not found
+	 * 409: A mapping with this title already exists
+	 * 424: Failed to edit the mapping
+	 */
+	#[NoAdminRequired]
+	#[CospendUserPermissions(minimumLevel: Application::ACCESS_LEVEL_MAINTAINER)]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Auto-categorisation'])]
+	public function editAutoCategoryMapping(string $projectId, int $mappingId, string $billTitle, int $categoryId): DataResponse {
+		try {
+			$mapping = $this->localProjectService->editAutoCategoryMapping($projectId, $mappingId, $billTitle, $categoryId);
+			return new DataResponse($mapping);
+		} catch (ClientException $e) {
+			return $this->getResponseFromClientException($e);
+		} catch (CospendBasicException $e) {
+			$code = $e->getCode() === Http::STATUS_NOT_FOUND ? Http::STATUS_NOT_FOUND : Http::STATUS_CONFLICT;
+			return new DataResponse($e->data, $code);
+		}
+	}
+
+	/**
+	 * Delete an auto-category mapping
+	 *
+	 * @param string $projectId
+	 * @param int $mappingId
+	 * @return DataResponse<Http::STATUS_OK, '', array{}>|DataResponse<Http::STATUS_NOT_FOUND|Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
+	 * @throws Exception
+	 *
+	 * 200: The mapping was successfully deleted
+	 * 404: The mapping was not found
+	 * 424: Failed to delete the mapping
+	 */
+	#[NoAdminRequired]
+	#[CospendUserPermissions(minimumLevel: Application::ACCESS_LEVEL_MAINTAINER)]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Auto-categorisation'])]
+	public function deleteAutoCategoryMapping(string $projectId, int $mappingId): DataResponse {
+		try {
+			$this->localProjectService->deleteAutoCategoryMapping($projectId, $mappingId);
+			return new DataResponse('');
+		} catch (ClientException $e) {
+			return $this->getResponseFromClientException($e);
+		} catch (CospendBasicException $e) {
+			return new DataResponse($e->data, Http::STATUS_NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Trigger auto-categorisation for a project
+	 *
+	 * @param string $projectId
+	 * @return DataResponse<Http::STATUS_OK, int, array{}>|DataResponse<Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
+	 * @throws Exception
+	 *
+	 * 200: Auto-categorisation completed, returns number of categorised bills
+	 * 424: Failed to auto-categorise
+	 */
+	#[NoAdminRequired]
+	#[CospendUserPermissions(minimumLevel: Application::ACCESS_LEVEL_MAINTAINER)]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Auto-categorisation'])]
+	public function autoCategorizeProject(string $projectId): DataResponse {
+		try {
+			$count = $this->localProjectService->autoCategorizeProjectBills($projectId);
+			return new DataResponse($count);
+		} catch (ClientException $e) {
+			return $this->getResponseFromClientException($e);
+		}
+	}
+
+	/**
+	 * Trigger auto-categorisation for all projects
+	 *
+	 * Admin-only: there is no project context for this endpoint
+	 *
+	 * @return DataResponse<Http::STATUS_OK, int, array{}>|DataResponse<Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
+	 * @throws Exception
+	 *
+	 * 200: Auto-categorisation completed, returns total number of categorised bills
+	 * 424: Failed to auto-categorise
+	 */
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Auto-categorisation'])]
+	public function autoCategorizeAll(): DataResponse {
+		try {
+			$count = $this->localProjectService->autoCategorizeAllBills();
+			return new DataResponse($count);
+		} catch (ClientException $e) {
+			return $this->getResponseFromClientException($e);
+		}
+	}
+
+	/**
+	 * Copy auto-category mappings from the current project to another project
+	 *
+	 * @param string $projectId Source project ID
+	 * @param string $targetProjectId Destination project ID
+	 * @param int|null $mappingId Restrict the copy to this single mapping
+	 * @return DataResponse<Http::STATUS_OK, CospendAutoCategoryMappingCopyResult, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{message: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND|Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
+	 *
+	 * 200: Mappings copied, returns {imported, skipped, errors}
+	 * 401: Current user is not allowed to edit mappings of the target project
+	 * 404: The mapping was not found
+	 * 424: Failed to copy mappings
+	 */
+	#[NoAdminRequired]
+	#[CospendUserPermissions(minimumLevel: Application::ACCESS_LEVEL_MAINTAINER)]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Auto-categorisation'])]
+	public function copyAutoCategoryMappings(string $projectId, string $targetProjectId, ?int $mappingId = null): DataResponse {
+		$userAccessLevel = $this->localProjectService->getUserMaxAccessLevel($this->userId, $targetProjectId);
+		if ($userAccessLevel < Application::ACCESS_LEVEL_MAINTAINER) {
+			return new DataResponse(['message' => $this->l->t('You are not allowed to edit mappings of the target project')], Http::STATUS_UNAUTHORIZED);
+		}
+		try {
+			$result = $this->localProjectService->copyAutoCategoryMappings($projectId, $targetProjectId, $mappingId);
+			return new DataResponse($result);
+		} catch (CospendBasicException $e) {
+			return new DataResponse($e->data, Http::STATUS_NOT_FOUND);
+		} catch (ClientException $e) {
+			return $this->getResponseFromClientException($e);
+		}
+	}
+
+	/**
+	 * Import auto-category mappings from another project into the current project
+	 *
+	 * @param string $projectId Destination project ID
+	 * @param string $sourceProjectId Source project ID
+	 * @return DataResponse<Http::STATUS_OK, CospendAutoCategoryMappingCopyResult, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_FAILED_DEPENDENCY, array<string, string>, array{}>
+	 *
+	 * 200: Mappings imported, returns {imported, skipped, errors}
+	 * 400: Invalid source project
+	 * 401: Current user is not allowed to access the source project
+	 * 424: Failed to import mappings
+	 */
+	#[NoAdminRequired]
+	#[CospendUserPermissions(minimumLevel: Application::ACCESS_LEVEL_MAINTAINER)]
+	#[OpenAPI(scope: OpenAPI::SCOPE_DEFAULT, tags: ['Auto-categorisation'])]
+	public function importAutoCategoryMappings(string $projectId, string $sourceProjectId): DataResponse {
+		$userAccessLevel = $this->localProjectService->getUserMaxAccessLevel($this->userId, $sourceProjectId);
+		if ($userAccessLevel < Application::ACCESS_LEVEL_VIEWER) {
+			return new DataResponse(['message' => $this->l->t('You are not allowed to access the source project')], Http::STATUS_UNAUTHORIZED);
+		}
+		try {
+			$result = $this->localProjectService->copyAutoCategoryMappings($sourceProjectId, $projectId);
+			return new DataResponse($result);
 		} catch (ClientException $e) {
 			return $this->getResponseFromClientException($e);
 		}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -92,6 +92,9 @@ class PageController extends Controller {
 		}
 		$state['useTime'] = ($state['useTime'] ?? '0') !== '0';
 		$state['showMyBalance'] = ($state['showMyBalance'] ?? '0') !== '0';
+		$state['auto_categorization_enabled'] = $this->appConfig->getValueString(
+			Application::APP_ID, 'auto_categorization_enabled', '1', lazy: true
+		) === '1';
 
 		$this->initialStateService->provideInitialState('cospend-state', $state);
 		$this->eventDispatcher->dispatchTyped(new RenderReferenceEvent());

--- a/lib/Controller/PublicApiController.php
+++ b/lib/Controller/PublicApiController.php
@@ -323,6 +323,7 @@ class PublicApiController extends OCSController {
 	 * @param string|null $comment
 	 * @param int|null $repeatFreq
 	 * @param int|null $deleted
+	 * @param bool $autoCategorise
 	 * @return DataResponse<Http::STATUS_OK, int, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array<string, string>, array{}>
 	 * @throws Exception
 	 */
@@ -338,14 +339,15 @@ class PublicApiController extends OCSController {
 		?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, ?int $repeatAllActive = null,
 		?string $repeatUntil = null, ?int $timestamp = null, ?string $comment = null,
-		?int $repeatFreq = null, ?int $deleted = null,
+		?int $repeatFreq = null, ?int $deleted = null, bool $autoCategorise = true,
 	): DataResponse {
 		$share = $this->shareMapper->getLinkOrFederatedShareByToken($token);
 		try {
 			$this->localProjectService->editBill(
 				$this->projectId, $billId, $date, $what, $payer, $payedFor,
 				$amount, $repeat, $paymentMode, $paymentModeId, $categoryId,
-				$repeatAllActive, $repeatUntil, $timestamp, $comment, $repeatFreq, $deleted
+				$repeatAllActive, $repeatUntil, $timestamp, $comment, $repeatFreq, $deleted,
+				false, $autoCategorise
 			);
 			$billObj = $this->billMapper->find($billId);
 			$this->activityManager->triggerEvent(
@@ -454,6 +456,7 @@ class PublicApiController extends OCSController {
 	 * @param string|null $categorySort
 	 * @param string|null $paymentModeSort
 	 * @param int|null $archivedTs
+	 * @param string|null $autoCategorization
 	 * @return DataResponse<Http::STATUS_OK, '', array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array<string, string>, array{}>
 	 */
 	#[NoAdminRequired]
@@ -466,11 +469,13 @@ class PublicApiController extends OCSController {
 		string $token, ?string $name = null,
 		?string $autoExport = null, ?string $currencyName = null, ?bool $deletionDisabled = null,
 		?string $categorySort = null, ?string $paymentModeSort = null, ?int $archivedTs = null,
+		?string $autoCategorization = null,
 	): DataResponse {
 		try {
 			$this->localProjectService->editProject(
 				$this->projectId, $name, null, $autoExport,
-				$currencyName, $deletionDisabled, $categorySort, $paymentModeSort, $archivedTs
+				$currencyName, $deletionDisabled, $categorySort, $paymentModeSort, $archivedTs,
+				$autoCategorization
 			);
 			return new DataResponse('');
 		} catch (CospendBasicException $e) {
@@ -496,6 +501,7 @@ class PublicApiController extends OCSController {
 	 * @param int|null $timestamp
 	 * @param string|null $comment
 	 * @param int|null $repeatFreq
+	 * @param bool $autoCategorise
 	 * @return DataResponse<Http::STATUS_OK, int, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 * @throws DoesNotExistException
 	 * @throws Exception
@@ -512,14 +518,14 @@ class PublicApiController extends OCSController {
 		?string $payedFor = null, ?float $amount = null, string $repeat = 'n',
 		?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, int $repeatAllActive = 0, ?string $repeatUntil = null, ?int $timestamp = null,
-		?string $comment = null, ?int $repeatFreq = null,
+		?string $comment = null, ?int $repeatFreq = null, bool $autoCategorise = true,
 	): DataResponse {
 		$share = $this->shareMapper->getLinkOrFederatedShareByToken($token);
 		try {
 			$insertedId = $this->localProjectService->createBill(
 				$this->projectId, $date, $what, $payer, $payedFor, $amount,
 				$repeat, $paymentMode, $paymentModeId, $categoryId, $repeatAllActive,
-				$repeatUntil, $timestamp, $comment, $repeatFreq
+				$repeatUntil, $timestamp, $comment, $repeatFreq, 0, false, $autoCategorise
 			);
 			$billObj = $this->billMapper->find($insertedId);
 			$this->activityManager->triggerEvent(

--- a/lib/Db/AutoCategoryMapping.php
+++ b/lib/Db/AutoCategoryMapping.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Cospend\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * @method void setProjectId(string $projectId)
+ * @method string getProjectId()
+ * @method void setBillTitle(string $billTitle)
+ * @method string getBillTitle()
+ * @method void setCategoryId(int|null $categoryId)
+ * @method int|null getCategoryId()
+ * @method void setLastChanged(int $lastChanged)
+ * @method int getLastChanged()
+ * @method void setCreatedAt(int $createdAt)
+ * @method int getCreatedAt()
+ */
+class AutoCategoryMapping extends Entity implements \JsonSerializable {
+
+	protected $projectId;
+	protected $billTitle;
+	protected $categoryId;
+	protected $lastChanged;
+	protected $createdAt;
+
+	public function __construct() {
+		$this->addType('projectId', Types::STRING);
+		$this->addType('billTitle', Types::STRING);
+		$this->addType('categoryId', Types::INTEGER);
+		$this->addType('lastChanged', Types::INTEGER);
+		$this->addType('createdAt', Types::INTEGER);
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->getId(),
+			'project_id' => $this->getProjectId(),
+			'bill_title' => $this->getBillTitle(),
+			'category_id' => $this->getCategoryId(),
+			'last_changed' => $this->getLastChanged(),
+			'created_at' => $this->getCreatedAt(),
+		];
+	}
+}

--- a/lib/Db/AutoCategoryMappingMapper.php
+++ b/lib/Db/AutoCategoryMappingMapper.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Cospend\Db;
+
+use DateTime;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<AutoCategoryMapping>
+ */
+class AutoCategoryMappingMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'cospend_auto_category_mappings', AutoCategoryMapping::class);
+	}
+
+	/**
+	 * Get a mapping by ID
+	 *
+	 * @param int $id
+	 * @return AutoCategoryMapping|null
+	 * @throws Exception
+	 */
+	public function getById(int $id): ?AutoCategoryMapping {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+
+		try {
+			return $this->findEntity($qb);
+		} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Get all mappings for a project
+	 *
+	 * @param string $projectId
+	 * @return AutoCategoryMapping[]
+	 * @throws Exception
+	 */
+	public function getMappings(string $projectId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'project_id', 'bill_title', 'category_id', 'last_changed', 'created_at')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('project_id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_STR)));
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Find a mapping by project and bill title (case-insensitive)
+	 *
+	 * @param string $projectId
+	 * @param string $billTitle
+	 * @return AutoCategoryMapping|null
+	 * @throws Exception
+	 */
+	public function findMapping(string $projectId, string $billTitle): ?AutoCategoryMapping {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'project_id', 'bill_title', 'category_id', 'last_changed', 'created_at')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('project_id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq(
+				$qb->createFunction('LOWER(' . $qb->getColumnName('bill_title') . ')'),
+				$qb->createNamedParameter(strtolower($billTitle), IQueryBuilder::PARAM_STR)
+			))
+			// case-variant duplicates are rejected on creation but might predate that check,
+			// prefer the most recently changed one
+			->orderBy('last_changed', 'DESC')
+			->setMaxResults(1);
+
+		$mappings = $this->findEntities($qb);
+		return $mappings[0] ?? null;
+	}
+
+	/**
+	 * Nullify category_id on mappings that reference a deleted category
+	 *
+	 * @param string $projectId
+	 * @param int $categoryId
+	 * @return void
+	 * @throws Exception
+	 */
+	public function nullifyCategoryId(string $projectId, int $categoryId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->update($this->getTableName())
+			->set('category_id', $qb->createNamedParameter(null, IQueryBuilder::PARAM_INT))
+			->set('last_changed', $qb->createNamedParameter((new DateTime())->getTimestamp(), IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('project_id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->eq('category_id', $qb->createNamedParameter($categoryId, IQueryBuilder::PARAM_INT)));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Db/Project.php
+++ b/lib/Db/Project.php
@@ -32,6 +32,8 @@ use OCP\DB\Types;
  * @method \void setCurrencyName(\string|\null $currencyName)
  * @method \int|\null getArchivedTs()
  * @method \void setArchivedTs(\int|\null $archivedTs)
+ * @method \string getAutoCategorization()
+ * @method \void setAutoCategorization(\string $autoCategorization)
  */
 class Project extends Entity implements \JsonSerializable {
 
@@ -44,6 +46,7 @@ class Project extends Entity implements \JsonSerializable {
 	protected $paymentModeSort;
 	protected $currencyName;
 	protected $archivedTs;
+	protected $autoCategorization;
 
 	public function __construct() {
 		$this->addType('id', Types::STRING);
@@ -56,6 +59,7 @@ class Project extends Entity implements \JsonSerializable {
 		$this->addType('paymentModeSort', Types::STRING);
 		$this->addType('currencyName', Types::STRING);
 		$this->addType('archivedTs', Types::INTEGER);
+		$this->addType('autoCategorization', Types::STRING);
 	}
 
 	#[\ReturnTypeWillChange]
@@ -72,6 +76,7 @@ class Project extends Entity implements \JsonSerializable {
 			'paymentmodesort' => $this->getPaymentModeSort(),
 			'currencyname' => $this->getCurrencyName(),
 			'archived_ts' => $this->getArchivedTs(),
+			'auto_categorization' => $this->getAutoCategorization(),
 		];
 	}
 }

--- a/lib/Db/ProjectMapper.php
+++ b/lib/Db/ProjectMapper.php
@@ -145,6 +145,19 @@ class ProjectMapper extends QBMapper {
 	}
 
 	/**
+	 * @return Project[]
+	 * @throws Exception
+	 */
+	public function getAll(): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName());
+
+		return $this->findEntities($qb);
+	}
+
+	/**
 	 * @param string $userId
 	 * @return Project[]
 	 * @throws Exception

--- a/lib/Migration/Version040003Date20250711000000.php
+++ b/lib/Migration/Version040003Date20250711000000.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Cospend\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-categorisation feature (gh-402):
+ * - Creates cospend_auto_category_mappings for bill title → category mappings
+ * - Adds auto_categorization column to cospend_projects (per-project toggle)
+ */
+class Version040003Date20250711000000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$schemaChanged = false;
+
+		if (!$schema->hasTable('cospend_auto_category_mappings')) {
+			$table = $schema->createTable('cospend_auto_category_mappings');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 4,
+			]);
+			$table->addColumn('project_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('bill_title', Types::STRING, [
+				'notnull' => true,
+				'length' => 300,
+			]);
+			$table->addColumn('category_id', Types::INTEGER, [
+				'notnull' => false,
+				'length' => 4,
+				'default' => null,
+			]);
+			$table->addColumn('last_changed', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 4,
+				'default' => 0,
+			]);
+			$table->addColumn('created_at', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 4,
+				'default' => 0,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['project_id', 'bill_title'], 'acm_project_title_idx');
+			$table->addIndex(['project_id', 'category_id'], 'acm_project_cat_idx');
+			$schemaChanged = true;
+		}
+
+		if ($schema->hasTable('cospend_projects')) {
+			$table = $schema->getTable('cospend_projects');
+			if (!$table->hasColumn('auto_categorization')) {
+				$table->addColumn('auto_categorization', Types::STRING, [
+					'notnull' => true,
+					'length' => 1,
+					'default' => '1',
+				]);
+				$schemaChanged = true;
+			}
+		}
+
+		return $schemaChanged ? $schema : null;
+	}
+}

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -86,6 +86,21 @@ namespace OCA\Cospend;
  *     projectid: string,
  *  }
  *
+ * @psalm-type CospendAutoCategoryMapping = array{
+ *     id: int,
+ *     project_id: string,
+ *     bill_title: string,
+ *     category_id: ?int,
+ *     last_changed: int,
+ *     created_at: int,
+ *  }
+ *
+ * @psalm-type CospendAutoCategoryMappingCopyResult = array{
+ *     imported: int,
+ *     skipped: int,
+ *     errors: list<string>,
+ *  }
+ *
  * @psalm-type CospendCategoryOrPaymentMode = array{
  *     id: int,
  *     projectid: string,

--- a/lib/Service/FederatedProjectService.php
+++ b/lib/Service/FederatedProjectService.php
@@ -150,7 +150,7 @@ class FederatedProjectService implements IProjectService {
 		?float $amount, ?string $repeat, ?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, int $repeatAllActive = 0, ?string $repeatUntil = null,
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null,
-		int $deleted = 0, bool $produceActivity = false,
+		int $deleted = 0, bool $produceActivity = false, bool $autoCategorise = true,
 	): int {
 		$params = [
 			'date' => $date,
@@ -169,6 +169,7 @@ class FederatedProjectService implements IProjectService {
 			'repeatFreq' => $repeatFreq,
 			'deleted' => $deleted,
 			'produceActivity' => $produceActivity,
+			'autoCategorise' => $autoCategorise ? '1' : '0',
 		];
 		return $this->request($projectId, 'api/v1/public/projects/{token}/{password}/bills', $params, 'POST');
 	}
@@ -193,7 +194,7 @@ class FederatedProjectService implements IProjectService {
 		?float $amount, ?string $repeat, ?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, ?int $repeatAllActive = null, ?string $repeatUntil = null,
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null,
-		?int $deleted = null, bool $produceActivity = false,
+		?int $deleted = null, bool $produceActivity = false, bool $autoCategorise = true,
 	): void {
 		$params = [
 			'date' => $date,
@@ -211,6 +212,7 @@ class FederatedProjectService implements IProjectService {
 			'comment' => $comment,
 			'repeatFreq' => $repeatFreq,
 			'deleted' => $deleted,
+			'autoCategorise' => $autoCategorise ? '1' : '0',
 		];
 		$this->request($projectId, 'api/v1/public/projects/{token}/{password}/bills/' . $billId, $params, 'PUT');
 	}
@@ -293,6 +295,7 @@ class FederatedProjectService implements IProjectService {
 		string $projectId, ?string $name = null, ?string $contact_email = null,
 		?string $autoExport = null, ?string $currencyName = null, ?bool $deletionDisabled = null,
 		?string $categorySort = null, ?string $paymentModeSort = null, ?int $archivedTs = null,
+		?string $autoCategorization = null,
 	): void {
 		$params = [
 			'name' => $name,
@@ -303,6 +306,7 @@ class FederatedProjectService implements IProjectService {
 			'categorySort' => $categorySort,
 			'paymentModeSort' => $paymentModeSort,
 			'archivedTs' => $archivedTs,
+			'autoCategorization' => $autoCategorization,
 		];
 		$this->request($projectId, 'api/v1/public/projects/{token}/{password}', $params, 'PUT');
 	}

--- a/lib/Service/IProjectService.php
+++ b/lib/Service/IProjectService.php
@@ -108,6 +108,7 @@ interface IProjectService {
 		string $projectId, ?string $name = null, ?string $contact_email = null,
 		?string $autoExport = null, ?string $currencyName = null, ?bool $deletionDisabled = null,
 		?string $categorySort = null, ?string $paymentModeSort = null, ?int $archivedTs = null,
+		?string $autoCategorization = null,
 	): void;
 
 	/**
@@ -201,7 +202,7 @@ interface IProjectService {
 		?float $amount, ?string $repeat, ?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, int $repeatAllActive = 0, ?string $repeatUntil = null,
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null,
-		int $deleted = 0, bool $produceActivity = false,
+		int $deleted = 0, bool $produceActivity = false, bool $autoCategorise = true,
 	): int;
 
 	/**
@@ -254,7 +255,7 @@ interface IProjectService {
 		?float $amount, ?string $repeat, ?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, ?int $repeatAllActive = null, ?string $repeatUntil = null,
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null,
-		?int $deleted = null, bool $produceActivity = false,
+		?int $deleted = null, bool $produceActivity = false, bool $autoCategorise = true,
 	): void;
 
 	/**

--- a/lib/Service/LocalProjectService.php
+++ b/lib/Service/LocalProjectService.php
@@ -15,6 +15,8 @@ use DateTimeZone;
 use Exception;
 use OCA\Cospend\Activity\ActivityManager;
 use OCA\Cospend\AppInfo\Application;
+use OCA\Cospend\Db\AutoCategoryMapping;
+use OCA\Cospend\Db\AutoCategoryMappingMapper;
 use OCA\Cospend\Db\Bill;
 use OCA\Cospend\Db\BillMapper;
 use OCA\Cospend\Db\BillOwer;
@@ -79,6 +81,7 @@ class LocalProjectService implements IProjectService {
 		private PaymentModeMapper $paymentModeMapper,
 		private CategoryMapper $categoryMapper,
 		private BillOwerMapper $billOwerMapper,
+		private AutoCategoryMappingMapper $autoCategoryMappingMapper,
 		private BackendNotifier $backendNotifier,
 		private ICloudIdManager $cloudIdManager,
 		private ActivityManager $activityManager,
@@ -316,6 +319,7 @@ class LocalProjectService implements IProjectService {
 			'cospend_currencies' => 'project_id',
 			'cospend_categories' => 'project_id',
 			'cospend_paymentmodes' => 'project_id',
+			'cospend_auto_category_mappings' => 'project_id',
 		];
 
 		foreach ($associatedTableNames as $tableName => $projectIdColumn) {
@@ -921,7 +925,7 @@ class LocalProjectService implements IProjectService {
 		?float $amount, ?string $repeat, ?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, int $repeatAllActive = 0, ?string $repeatUntil = null,
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null,
-		int $deleted = 0, bool $produceActivity = false,
+		int $deleted = 0, bool $produceActivity = false, bool $autoCategorise = true,
 	): int {
 		// if we don't have the payment modes, get them now
 		if ($this->paymentModes === null) {
@@ -1015,6 +1019,15 @@ class LocalProjectService implements IProjectService {
 		$newBill->setRepeatAllActive($repeatAllActive);
 		$newBill->setRepeatUntil($repeatUntil);
 		$newBill->setRepeatFrequency($repeatFreq ?? 1);
+		// auto-categorisation: if no category provided and mapping exists, assign category
+		if ($autoCategorise && ($categoryId === null || $categoryId === 0) && $what !== '') {
+			if ($this->isAutoCategorizationEnabled($projectId)) {
+				$mappedCategoryId = $this->autoCategorizeBill($projectId, $what);
+				if ($mappedCategoryId !== null) {
+					$categoryId = $mappedCategoryId;
+				}
+			}
+		}
 		$newBill->setCategoryId($categoryId ?? 0);
 		$newBill->setPaymentMode($paymentMode ?? 'n');
 		$newBill->setPaymentModeId($paymentModeId ?? 0);
@@ -1431,6 +1444,7 @@ class LocalProjectService implements IProjectService {
 		string $projectId, ?string $name = null, ?string $contact_email = null,
 		?string $autoExport = null, ?string $currencyName = null, ?bool $deletionDisabled = null,
 		?string $categorySort = null, ?string $paymentModeSort = null, ?int $archivedTs = null,
+		?string $autoCategorization = null,
 	): void {
 		$dbProject = $this->projectMapper->find($projectId);
 		if ($dbProject === null) {
@@ -1478,6 +1492,9 @@ class LocalProjectService implements IProjectService {
 		}
 		if ($currencyName !== null) {
 			$dbProject->setCurrencyName($currencyName === '' ? null : $currencyName);
+		}
+		if ($autoCategorization !== null) {
+			$dbProject->setAutoCategorization($autoCategorization);
 		}
 		$ts = (new DateTime())->getTimestamp();
 		$dbProject->setLastChanged($ts);
@@ -2148,7 +2165,7 @@ class LocalProjectService implements IProjectService {
 		?float $amount, ?string $repeat, ?string $paymentMode = null, ?int $paymentModeId = null,
 		?int $categoryId = null, ?int $repeatAllActive = null, ?string $repeatUntil = null,
 		?int $timestamp = null, ?string $comment = null, ?int $repeatFreq = null,
-		?int $deleted = null, bool $produceActivity = false,
+		?int $deleted = null, bool $produceActivity = false, bool $autoCategorise = true,
 	): void {
 		// if we don't have the payment modes, get them now
 		if ($this->paymentModes === null) {
@@ -2255,6 +2272,16 @@ class LocalProjectService implements IProjectService {
 		}
 		if ($categoryId !== null) {
 			$dbBill->setCategoryId($categoryId);
+		}
+		// auto-categorisation: if category not explicitly provided and bill is uncategorised
+		if ($autoCategorise && $categoryId === null && (int)$dbBill->getCategoryId() === 0) {
+			$billTitle = $what ?? $dbBill->getWhat();
+			if ($billTitle !== '' && $this->isAutoCategorizationEnabled($projectId)) {
+				$mappedCategoryId = $this->autoCategorizeBill($projectId, $billTitle);
+				if ($mappedCategoryId !== null) {
+					$dbBill->setCategoryId($mappedCategoryId);
+				}
+			}
 		}
 		// priority to timestamp (moneybuster might send both for a moment)
 		if ($timestamp !== null) {
@@ -2885,6 +2912,9 @@ class LocalProjectService implements IProjectService {
 
 		// then get rid of this category in bills
 		$this->billMapper->removeCategoryInProject($projectId, $categoryId);
+
+		// auto-categorisation: nullify category_id in affected mappings so they show as invalid
+		$this->autoCategoryMappingMapper->nullifyCategoryId($projectId, $categoryId);
 	}
 
 	/**
@@ -2931,6 +2961,319 @@ class LocalProjectService implements IProjectService {
 		$category->setEncodedIcon(($icon !== null && $icon !== '') ? urlencode($icon) : $icon);
 		$editedCategory = $this->categoryMapper->update($category);
 		return $editedCategory->jsonSerialize();
+	}
+
+	/**
+	 * Get all auto-category mappings for a project
+	 *
+	 * @param string $projectId
+	 * @return array
+	 * @throws \OCP\DB\Exception
+	 */
+	public function getAutoCategoryMappings(string $projectId): array {
+		$mappings = $this->autoCategoryMappingMapper->getMappings($projectId);
+		return array_map(function (AutoCategoryMapping $m) {
+			return $m->jsonSerialize();
+		}, $mappings);
+	}
+
+	/**
+	 * Create a new auto-category mapping
+	 *
+	 * @param string $projectId
+	 * @param string $billTitle
+	 * @param int $categoryId
+	 * @return int
+	 * @throws \OCP\DB\Exception
+	 */
+	public function createAutoCategoryMapping(string $projectId, string $billTitle, int $categoryId): int {
+		// the unique DB index is case-sensitive, check for case-insensitive duplicates here
+		if ($this->autoCategoryMappingMapper->findMapping($projectId, $billTitle) !== null) {
+			throw new CospendBasicException(
+				'A mapping with this title already exists',
+				Http::STATUS_CONFLICT,
+				['message' => 'A mapping for \'' . $billTitle . '\' already exists']
+			);
+		}
+		$mapping = new AutoCategoryMapping();
+		$ts = (new DateTime())->getTimestamp();
+		$mapping->setProjectId($projectId);
+		$mapping->setBillTitle($billTitle);
+		$mapping->setCategoryId($categoryId);
+		$mapping->setLastChanged($ts);
+		$mapping->setCreatedAt($ts);
+		try {
+			$inserted = $this->autoCategoryMappingMapper->insert($mapping);
+		} catch (\OCP\DB\Exception $e) {
+			if ($e->getReason() === \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				throw new CospendBasicException(
+					'A mapping with this title already exists',
+					Http::STATUS_CONFLICT,
+					['message' => 'A mapping for \'' . $billTitle . '\' already exists']
+				);
+			}
+			throw $e;
+		}
+		return (int)$inserted->getId();
+	}
+
+	/**
+	 * Edit an auto-category mapping
+	 *
+	 * @param string $projectId
+	 * @param int $mappingId
+	 * @param string $billTitle
+	 * @param int $categoryId
+	 * @return array
+	 * @throws CospendBasicException
+	 * @throws \OCP\DB\Exception
+	 */
+	public function editAutoCategoryMapping(string $projectId, int $mappingId, string $billTitle, int $categoryId): array {
+		$mapping = $this->autoCategoryMappingMapper->getById($mappingId);
+		if ($mapping === null || $mapping->getProjectId() !== $projectId) {
+			throw new CospendBasicException('', Http::STATUS_NOT_FOUND, ['message' => 'mapping not found']);
+		}
+		// the unique DB index is case-sensitive, check for case-insensitive duplicates here
+		$existing = $this->autoCategoryMappingMapper->findMapping($projectId, $billTitle);
+		if ($existing !== null && $existing->getId() !== $mapping->getId()) {
+			throw new CospendBasicException(
+				'A mapping with this title already exists',
+				Http::STATUS_CONFLICT,
+				['message' => 'A mapping for \'' . $billTitle . '\' already exists']
+			);
+		}
+		$mapping->setBillTitle($billTitle);
+		$mapping->setCategoryId($categoryId);
+		$mapping->setLastChanged((new DateTime())->getTimestamp());
+		try {
+			$updated = $this->autoCategoryMappingMapper->update($mapping);
+		} catch (\OCP\DB\Exception $e) {
+			if ($e->getReason() === \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				throw new CospendBasicException(
+					'A mapping with this title already exists',
+					Http::STATUS_CONFLICT,
+					['message' => 'A mapping for \'' . $billTitle . '\' already exists']
+				);
+			}
+			throw $e;
+		}
+		return $updated->jsonSerialize();
+	}
+
+	/**
+	 * Delete an auto-category mapping
+	 *
+	 * @param string $projectId
+	 * @param int $mappingId
+	 * @return void
+	 * @throws CospendBasicException
+	 * @throws \OCP\DB\Exception
+	 */
+	public function deleteAutoCategoryMapping(string $projectId, int $mappingId): void {
+		$mapping = $this->autoCategoryMappingMapper->getById($mappingId);
+		if ($mapping === null || $mapping->getProjectId() !== $projectId) {
+			throw new CospendBasicException('', Http::STATUS_NOT_FOUND, ['message' => 'mapping not found']);
+		}
+		$this->autoCategoryMappingMapper->delete($mapping);
+	}
+
+	/**
+	 * Check if auto-categorisation is enabled for a project (global + per-project)
+	 *
+	 * @param string $projectId
+	 * @return bool
+	 * @throws \OCP\DB\Exception
+	 */
+	public function isAutoCategorizationEnabled(string $projectId): bool {
+		// global toggle (app config)
+		$globallyEnabled = $this->appConfig->getValueString(
+			Application::APP_ID, 'auto_categorization_enabled', '1', lazy: true
+		) === '1';
+		if (!$globallyEnabled) {
+			return false;
+		}
+		// per-project toggle
+		$project = $this->projectMapper->find($projectId);
+		if ($project === null) {
+			return false;
+		}
+		return $project->getAutoCategorization() === '1';
+	}
+
+	/**
+	 * Auto-categorize a bill title by looking up the mappings.
+	 * Returns the category ID if a matching mapping is found, null otherwise.
+	 *
+	 * @param string $projectId
+	 * @param string $billTitle
+	 * @return int|null
+	 * @throws \OCP\DB\Exception
+	 */
+	public function autoCategorizeBill(string $projectId, string $billTitle): ?int {
+		if ($billTitle === '') {
+			return null;
+		}
+		$mapping = $this->autoCategoryMappingMapper->findMapping($projectId, $billTitle);
+		if ($mapping !== null && $mapping->getCategoryId() !== null) {
+			return $mapping->getCategoryId();
+		}
+		return null;
+	}
+
+	/**
+	 * Auto-categorize all uncategorized bills in a project.
+	 * Returns the number of bills that were categorized.
+	 *
+	 * @param string $projectId
+	 * @return int
+	 * @throws \OCP\DB\Exception
+	 */
+	public function autoCategorizeProjectBills(string $projectId): int {
+		$count = 0;
+		$mappings = $this->autoCategoryMappingMapper->getMappings($projectId);
+		if (empty($mappings)) {
+			return 0;
+		}
+
+		foreach ($mappings as $m) {
+			$categoryId = $m->getCategoryId();
+			if ($categoryId === null) {
+				continue;
+			}
+			$qb = $this->db->getQueryBuilder();
+			$qb->update('cospend_bills')
+				->set('category_id', $qb->createNamedParameter($categoryId, IQueryBuilder::PARAM_INT))
+				->where($qb->expr()->eq('project_id', $qb->createNamedParameter($projectId, IQueryBuilder::PARAM_STR)))
+				->andWhere($qb->expr()->eq('category_id', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+				->andWhere($qb->expr()->eq(
+					$qb->createFunction('LOWER(' . $qb->getColumnName('what') . ')'),
+					$qb->createNamedParameter(strtolower($m->getBillTitle()), IQueryBuilder::PARAM_STR)
+				));
+			$count += $qb->executeStatement();
+		}
+		return $count;
+	}
+
+	/**
+	 * Auto-categorize all uncategorized bills across all non-archived projects
+	 * that have auto-categorisation enabled.
+	 * Returns the total number of bills categorized.
+	 *
+	 * @return int
+	 * @throws \OCP\DB\Exception
+	 */
+	public function autoCategorizeAllBills(): int {
+		$totalCount = 0;
+		$projects = $this->projectMapper->getAll();
+		foreach ($projects as $project) {
+			if ($project->getAutoCategorization() === '1' && $project->getArchivedTs() === null) {
+				if ($this->isAutoCategorizationEnabled((string)$project->getId())) {
+					$totalCount += $this->autoCategorizeProjectBills((string)$project->getId());
+				}
+			}
+		}
+		return $totalCount;
+	}
+
+	/**
+	 * Copy auto-category mappings from source project to target project.
+	 * For each mapping, it finds a category in the target project with the same name.
+	 * Returns a summary array with counts.
+	 *
+	 * @param string $sourceProjectId
+	 * @param string $targetProjectId
+	 * @param int|null $mappingId only copy this mapping instead of all of them
+	 * @return array{imported: int, skipped: int, errors: list<string>}
+	 * @throws CospendBasicException
+	 * @throws \OCP\DB\Exception
+	 */
+	public function copyAutoCategoryMappings(string $sourceProjectId, string $targetProjectId, ?int $mappingId = null): array {
+		$sourceMappings = $this->autoCategoryMappingMapper->getMappings($sourceProjectId);
+		if ($mappingId !== null) {
+			$sourceMappings = array_values(array_filter($sourceMappings, static function (AutoCategoryMapping $m) use ($mappingId) {
+				return $m->getId() === $mappingId;
+			}));
+			if (empty($sourceMappings)) {
+				throw new CospendBasicException('', Http::STATUS_NOT_FOUND, ['message' => 'mapping not found']);
+			}
+		}
+		$targetCategories = $this->categoryMapper->getCategoriesOfProject($targetProjectId);
+		$existingMappings = $this->autoCategoryMappingMapper->getMappings($targetProjectId);
+
+		// Build target category lookup by name (case-insensitive)
+		$catLookup = [];
+		foreach ($targetCategories as $cat) {
+			$catLookup[strtolower($cat->getName())] = $cat->getId();
+		}
+
+		// Build set of existing mapping titles (case-insensitive)
+		$existingTitles = [];
+		foreach ($existingMappings as $m) {
+			$existingTitles[strtolower($m->getBillTitle())] = true;
+		}
+
+		$imported = 0;
+		$skipped = 0;
+		$errors = [];
+
+		foreach ($sourceMappings as $mapping) {
+			$title = $mapping->getBillTitle();
+			$lowerTitle = strtolower($title);
+			$sourceCategoryId = $mapping->getCategoryId();
+
+			if ($sourceCategoryId === null) {
+				$skipped++;
+				continue;
+			}
+
+			// Get source category name
+			try {
+				$sourceCategory = $this->categoryMapper->getCategoryOfProject($sourceProjectId, $sourceCategoryId);
+				$sourceCategoryName = $sourceCategory->getName();
+			} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
+				$errors[] = "Source category $sourceCategoryId not found";
+				$skipped++;
+				continue;
+			}
+
+			if ($sourceCategoryName === null || $sourceCategoryName === '') {
+				$skipped++;
+				continue;
+			}
+
+			// Check if target project has a category with the same name
+			$lowerName = strtolower($sourceCategoryName);
+			if (!isset($catLookup[$lowerName])) {
+				$errors[] = "No matching category '$sourceCategoryName' in target project";
+				$skipped++;
+				continue;
+			}
+
+			// Check for duplicate title mapping
+			if (isset($existingTitles[$lowerTitle])) {
+				$errors[] = "Mapping already exists for '$title'";
+				$skipped++;
+				continue;
+			}
+
+			// Create the mapping
+			$targetCategoryId = $catLookup[$lowerName];
+			$newMapping = new AutoCategoryMapping();
+			$ts = (new DateTime())->getTimestamp();
+			$newMapping->setProjectId($targetProjectId);
+			$newMapping->setBillTitle($title);
+			$newMapping->setCategoryId($targetCategoryId);
+			$newMapping->setLastChanged($ts);
+			$newMapping->setCreatedAt($ts);
+			$this->autoCategoryMappingMapper->insert($newMapping);
+			$imported++;
+		}
+
+		return [
+			'imported' => $imported,
+			'skipped' => $skipped,
+			'errors' => $errors,
+		];
 	}
 
 	/**

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -27,10 +27,12 @@ class Admin implements ISettings {
 	public function getForm(): TemplateResponse {
 		$federationEnabled = $this->appConfig->getValueString(Application::APP_ID, 'federation_enabled', '0', lazy: true) === '1';
 		$balancePastBillsOnly = $this->appConfig->getValueString(Application::APP_ID, 'balance_past_bills_only', '0', lazy: true) === '1';
+		$autoCategorizationEnabled = $this->appConfig->getValueString(Application::APP_ID, 'auto_categorization_enabled', '1', lazy: true) === '1';
 
 		$values = [
 			'federation_enabled' => $federationEnabled,
 			'balance_past_bills_only' => $balancePastBillsOnly,
+			'auto_categorization_enabled' => $autoCategorizationEnabled,
 		];
 		$this->initialStateService->provideInitialState('admin-settings', $values);
 

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -31,6 +31,66 @@
                     4
                 ]
             },
+            "AutoCategoryMapping": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "project_id",
+                    "bill_title",
+                    "category_id",
+                    "last_changed",
+                    "created_at"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "bill_title": {
+                        "type": "string"
+                    },
+                    "category_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    },
+                    "last_changed": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "created_at": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
+            "AutoCategoryMappingCopyResult": {
+                "type": "object",
+                "required": [
+                    "imported",
+                    "skipped",
+                    "errors"
+                ],
+                "properties": {
+                    "imported": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "skipped": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "BaseShare": {
                 "type": "object",
                 "required": [
@@ -1648,6 +1708,11 @@
                                     "archivedTs": {
                                         "type": "integer",
                                         "format": "int64",
+                                        "nullable": true,
+                                        "default": null
+                                    },
+                                    "autoCategorization": {
+                                        "type": "string",
                                         "nullable": true,
                                         "default": null
                                     }
@@ -3886,6 +3951,11 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorization": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null
                                     }
                                 }
                             }
@@ -4684,6 +4754,10 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorise": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             }
@@ -6149,6 +6223,10 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorise": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             }
@@ -7051,6 +7129,10 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorise": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             }
@@ -8399,6 +8481,10 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorise": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             }
@@ -16158,6 +16244,1594 @@
                     },
                     "400": {
                         "description": "Not saved",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-mappings": {
+            "get": {
+                "operationId": "api-get-auto-category-mappings",
+                "summary": "Get auto-category mappings for a project",
+                "description": "Viewer level is enough: mappings are applied client-side when typing a bill title, so every user who can see the project needs to be able to read them.",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The mappings were successfully fetched",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/AutoCategoryMapping"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to get the mappings",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "api-create-auto-category-mapping",
+                "summary": "Create an auto-category mapping",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "billTitle",
+                                    "categoryId"
+                                ],
+                                "properties": {
+                                    "billTitle": {
+                                        "type": "string"
+                                    },
+                                    "categoryId": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The mapping was successfully created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "A mapping with this title already exists",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to create the mapping",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-mappings/{mappingId}": {
+            "put": {
+                "operationId": "api-edit-auto-category-mapping",
+                "summary": "Edit an auto-category mapping",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "billTitle",
+                                    "categoryId"
+                                ],
+                                "properties": {
+                                    "billTitle": {
+                                        "type": "string"
+                                    },
+                                    "categoryId": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "mappingId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The mapping was successfully edited",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/AutoCategoryMapping"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The mapping was not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "A mapping with this title already exists",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to edit the mapping",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "api-delete-auto-category-mapping",
+                "summary": "Delete an auto-category mapping",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "mappingId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The mapping was successfully deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The mapping was not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to delete the mapping",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-categorize": {
+            "post": {
+                "operationId": "api-auto-categorize-project",
+                "summary": "Trigger auto-categorisation for a project",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Auto-categorisation completed, returns number of categorised bills",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to auto-categorise",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/auto-categorize": {
+            "post": {
+                "operationId": "api-auto-categorize-all",
+                "summary": "Trigger auto-categorisation for all projects",
+                "description": "Admin-only: there is no project context for this endpoint\nThis endpoint requires admin access",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Auto-categorisation completed, returns total number of categorised bills",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to auto-categorise",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Logged in account must be an admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-mappings/copy-to/{targetProjectId}": {
+            "post": {
+                "operationId": "api-copy-auto-category-mappings",
+                "summary": "Copy auto-category mappings from the current project to another project",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "mappingId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Restrict the copy to this single mapping"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "Source project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "targetProjectId",
+                        "in": "path",
+                        "description": "Destination project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Mappings copied, returns {imported, skipped, errors}",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/AutoCategoryMappingCopyResult"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not allowed to edit mappings of the target project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The mapping was not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to copy mappings",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-mappings/import-from/{sourceProjectId}": {
+            "post": {
+                "operationId": "api-import-auto-category-mappings",
+                "summary": "Import auto-category mappings from another project into the current project",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "Destination project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sourceProjectId",
+                        "in": "path",
+                        "description": "Source project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Mappings imported, returns {imported, skipped, errors}",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/AutoCategoryMappingCopyResult"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not allowed to access the source project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid source project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to import mappings",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/openapi.json
+++ b/openapi.json
@@ -31,6 +31,66 @@
                     4
                 ]
             },
+            "AutoCategoryMapping": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "project_id",
+                    "bill_title",
+                    "category_id",
+                    "last_changed",
+                    "created_at"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "bill_title": {
+                        "type": "string"
+                    },
+                    "category_id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    },
+                    "last_changed": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "created_at": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }
+            },
+            "AutoCategoryMappingCopyResult": {
+                "type": "object",
+                "required": [
+                    "imported",
+                    "skipped",
+                    "errors"
+                ],
+                "properties": {
+                    "imported": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "skipped": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "BaseShare": {
                 "type": "object",
                 "required": [
@@ -1607,6 +1667,11 @@
                                     "archivedTs": {
                                         "type": "integer",
                                         "format": "int64",
+                                        "nullable": true,
+                                        "default": null
+                                    },
+                                    "autoCategorization": {
+                                        "type": "string",
                                         "nullable": true,
                                         "default": null
                                     }
@@ -3845,6 +3910,11 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorization": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null
                                     }
                                 }
                             }
@@ -4643,6 +4713,10 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorise": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             }
@@ -6108,6 +6182,10 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorise": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             }
@@ -7010,6 +7088,10 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorise": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             }
@@ -8358,6 +8440,10 @@
                                         "format": "int64",
                                         "nullable": true,
                                         "default": null
+                                    },
+                                    "autoCategorise": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             }
@@ -16117,6 +16203,1594 @@
                     },
                     "400": {
                         "description": "Not saved",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-mappings": {
+            "get": {
+                "operationId": "api-get-auto-category-mappings",
+                "summary": "Get auto-category mappings for a project",
+                "description": "Viewer level is enough: mappings are applied client-side when typing a bill title, so every user who can see the project needs to be able to read them.",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The mappings were successfully fetched",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/AutoCategoryMapping"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to get the mappings",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "api-create-auto-category-mapping",
+                "summary": "Create an auto-category mapping",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "billTitle",
+                                    "categoryId"
+                                ],
+                                "properties": {
+                                    "billTitle": {
+                                        "type": "string"
+                                    },
+                                    "categoryId": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The mapping was successfully created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "A mapping with this title already exists",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to create the mapping",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-mappings/{mappingId}": {
+            "put": {
+                "operationId": "api-edit-auto-category-mapping",
+                "summary": "Edit an auto-category mapping",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "billTitle",
+                                    "categoryId"
+                                ],
+                                "properties": {
+                                    "billTitle": {
+                                        "type": "string"
+                                    },
+                                    "categoryId": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "mappingId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The mapping was successfully edited",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/AutoCategoryMapping"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The mapping was not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "A mapping with this title already exists",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to edit the mapping",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "api-delete-auto-category-mapping",
+                "summary": "Delete an auto-category mapping",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "mappingId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The mapping was successfully deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The mapping was not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to delete the mapping",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-categorize": {
+            "post": {
+                "operationId": "api-auto-categorize-project",
+                "summary": "Trigger auto-categorisation for a project",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Auto-categorisation completed, returns number of categorised bills",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to auto-categorise",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/auto-categorize": {
+            "post": {
+                "operationId": "api-auto-categorize-all",
+                "summary": "Trigger auto-categorisation for all projects",
+                "description": "Admin-only: there is no project context for this endpoint\nThis endpoint requires admin access",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Auto-categorisation completed, returns total number of categorised bills",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to auto-categorise",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Logged in account must be an admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-mappings/copy-to/{targetProjectId}": {
+            "post": {
+                "operationId": "api-copy-auto-category-mappings",
+                "summary": "Copy auto-category mappings from the current project to another project",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "mappingId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Restrict the copy to this single mapping"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "Source project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "targetProjectId",
+                        "in": "path",
+                        "description": "Destination project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Mappings copied, returns {imported, skipped, errors}",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/AutoCategoryMappingCopyResult"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not allowed to edit mappings of the target project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The mapping was not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to copy mappings",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/cospend/api/{apiVersion}/projects/{projectId}/auto-mappings/import-from/{sourceProjectId}": {
+            "post": {
+                "operationId": "api-import-auto-category-mappings",
+                "summary": "Import auto-category mappings from another project into the current project",
+                "tags": [
+                    "Auto-categorisation"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "apiVersion",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "v1"
+                            ],
+                            "default": "v1"
+                        }
+                    },
+                    {
+                        "name": "projectId",
+                        "in": "path",
+                        "description": "Destination project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sourceProjectId",
+                        "in": "path",
+                        "description": "Source project ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Mappings imported, returns {imported, skipped, errors}",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/AutoCategoryMappingCopyResult"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not allowed to access the source project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {
+                                                            "type": "object",
+                                                            "required": [
+                                                                "message"
+                                                            ],
+                                                            "properties": {
+                                                                "message": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "ocs"
+                                            ],
+                                            "properties": {
+                                                "ocs": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "meta",
+                                                        "data"
+                                                    ],
+                                                    "properties": {
+                                                        "meta": {
+                                                            "$ref": "#/components/schemas/OCSMeta"
+                                                        },
+                                                        "data": {}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid source project",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "424": {
+                        "description": "Failed to import mappings",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -354,6 +354,7 @@ export default {
 		subscribe('delete-bill', this.onDeleteBill)
 		subscribe('bill-moved', this.onBillMoved)
 		subscribe('bill-clicked', this.onBillClicked)
+		subscribe('reload-bills', this.onReloadBills)
 
 		subscribe('trashbin-clicked', this.onTrashbinClicked)
 		subscribe('close-trashbin', this.onCloseTrashbinClicked)
@@ -388,6 +389,7 @@ export default {
 		unsubscribe('delete-bill', this.onDeleteBill)
 		unsubscribe('bill-moved', this.onBillMoved)
 		unsubscribe('bill-clicked', this.onBillClicked)
+		unsubscribe('reload-bills', this.onReloadBills)
 
 		unsubscribe('trashbin-clicked', this.onTrashbinClicked)
 		unsubscribe('close-trashbin', this.onCloseTrashbinClicked)
@@ -423,6 +425,10 @@ export default {
 		onSetPaymentModeFilter(pmId) {
 			this.selectedPaymentModeFilter = pmId
 			this.onFilterChange()
+		},
+		onReloadBills() {
+			// bills were changed server-side (e.g. retroactive auto-categorisation)
+			this.getBills(this.cospend.currentProjectId, this.currentBill?.id, false, this.trashbinEnabled)
 		},
 		onFilterChange() {
 			// deselect current bill

--- a/src/BillForm.vue
+++ b/src/BillForm.vue
@@ -67,6 +67,7 @@
 						@trailing-button-click="myBill.what = ''; onBillEdited(null, false)"
 						@update:model-value="onBillEdited"
 						@keyup.enter="onBillEdited(null, false)"
+						@blur="onWhatBlur"
 						@focus="$refs.what.select()" />
 				</div>
 				<div v-if="!pageIsPublic"
@@ -208,6 +209,14 @@
 						:clearable="false"
 						@search="categoryQueryChanged"
 						@update:model-value="categorySelected" />
+				</div>
+				<div v-if="showSaveMappingCheckbox" class="bill-field save-mapping-row">
+					<NcCheckboxRadioSwitch
+						v-model="saveMappingChecked"
+						class="save-mapping-checkbox"
+						:disabled="!saveMappingExistingMapping && myBill.categoryid === 0">
+						{{ saveMappingLabel }}
+					</NcCheckboxRadioSwitch>
 				</div>
 				<div class="bill-field bill-comment">
 					<CommentTextIcon
@@ -580,7 +589,7 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import MemberAvatar from './components/avatar/MemberAvatar.vue'
 import MemberMultiSelect from './components/MemberMultiSelect.vue'
 
-import { emit } from '@nextcloud/event-bus'
+import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { generateUrl } from '@nextcloud/router'
 import { getCurrentUser } from '@nextcloud/auth'
 import { getLocale } from '@nextcloud/l10n'
@@ -592,10 +601,13 @@ import {
 } from '@nextcloud/dialogs'
 import moment from '@nextcloud/moment'
 import {
-	delay, getCategory, getPaymentMode, strcmp, evalAlgebricFormula,
+	delay, getCategory, getPaymentMode, strcmp, evalAlgebricFormula, decodeHtmlEntities, getErrorMessage,
 } from './utils.js'
 import * as network from './network.js'
 import * as constants from './constants.js'
+
+let cachedMappings = null
+let cachedProjectId = null
 
 export default {
 	name: 'BillForm',
@@ -682,6 +694,9 @@ export default {
 			showConvertInfo: false,
 			showAmountInfo: false,
 			showRepeatInfo: false,
+			autoMappings: [],
+			userTouchedCategory: false,
+			saveMappingChecked: false,
 		}
 	},
 
@@ -776,6 +791,43 @@ export default {
 				})
 			}
 			return categoryItems
+		},
+		showSaveMappingCheckbox() {
+			if (!this.userTouchedCategory || this.pageIsPublic) {
+				return false
+			}
+			const title = (this.myBill.what || '').trim()
+			if (title === '' || this.myBill.categoryid === 0) {
+				return false
+			}
+			return this.maintenerAccess && this.project.auto_categorization === '1' && OCA.Cospend.state.auto_categorization_enabled
+		},
+		autoMappingsMap() {
+			const map = new Map()
+			for (const m of this.autoMappings) {
+				map.set(m.bill_title.toLowerCase(), m)
+			}
+			return map
+		},
+		saveMappingExistingMapping() {
+			const title = (this.myBill.what || '').trim().toLowerCase()
+			if (!title) {
+				return null
+			}
+			return this.autoMappingsMap.get(title) || null
+		},
+		saveMappingLabel() {
+			const title = (this.myBill.what || '').trim()
+			const cat = getCategory(this.projectId, this.myBill.categoryid)
+			const catName = (cat.icon || '') + ' ' + cat.name
+			const existing = this.saveMappingExistingMapping
+			if (existing) {
+				const existingCat = getCategory(this.projectId, existing.category_id)
+				const existingCatName = (existingCat.icon || '') + ' ' + existingCat.name
+				return decodeHtmlEntities(t('cospend', 'Update existing mapping: {title} → {category}', { title, category: existingCatName })
+					+ ' — ' + t('cospend', 'Always assign {category}', { category: catName }))
+			}
+			return decodeHtmlEntities(t('cospend', 'Always assign {category} to bills titled "{title}"', { category: catName, title }))
 		},
 		useTime() {
 			return this.cospend.useTime
@@ -1037,6 +1089,14 @@ export default {
 			// reset formula when changing bill
 			this.currentFormula = null
 			this.newBillMode = 'normal'
+			this.userTouchedCategory = false
+		},
+		'myBill.what'() {
+			this.userTouchedCategory = false
+			this.saveMappingChecked = false
+		},
+		'myBill.categoryid'() {
+			this.saveMappingChecked = false
 		},
 		bill() {
 			this.myBill = {
@@ -1054,6 +1114,17 @@ export default {
 
 	mounted() {
 		this.$refs.what.focus()
+		this.fetchAutoMappings()
+		// mappings edited in the project settings should be picked up here
+		this._onMappingsChanged = () => {
+			cachedMappings = null
+			this.fetchAutoMappings()
+		}
+		subscribe('auto-category-mappings-changed', this._onMappingsChanged)
+	},
+
+	beforeUnmount() {
+		unsubscribe('auto-category-mappings-changed', this._onMappingsChanged)
 	},
 
 	methods: {
@@ -1115,6 +1186,7 @@ export default {
 			this.categoryQuery = query
 		},
 		categorySelected(selected) {
+			this.userTouchedCategory = true
 			if (!selected.isNewCategory) {
 				this.myBill.categoryid = selected.id
 				this.onBillEdited(null, false)
@@ -1238,6 +1310,9 @@ export default {
 				network.editBill(this.projectId, this.myBill).then((response) => {
 					// to update balances
 					this.$emit('bill-saved', this.bill, this.myBill)
+					if (this.saveMappingChecked) {
+						this.persistSaveMapping()
+					}
 					showSuccess(t('cospend', 'Bill saved'))
 				}).catch((error) => {
 					console.debug(error)
@@ -1529,6 +1604,9 @@ export default {
 			this.billLoading = true
 			network.createBill(this.projectId, req).then((response) => {
 				this.createBillSuccess(response.data.ocs.data, billToCreate, mode)
+				if (this.saveMappingChecked) {
+					this.persistSaveMapping()
+				}
 			}).catch((error) => {
 				showError(
 					t('cospend', 'Failed to create bill')
@@ -1559,6 +1637,45 @@ export default {
 		},
 		createBillDone() {
 			this.billLoading = false
+		},
+		persistSaveMapping() {
+			const title = (this.myBill.what || '').trim()
+			const catId = this.myBill.categoryid
+			if (!title || !catId) {
+				return
+			}
+			const existing = this.saveMappingExistingMapping
+			if (existing) {
+				network.editAutoCategoryMapping(this.projectId, existing.id, title, catId)
+					.then(() => {
+						existing.category_id = catId
+						cachedMappings = null
+						showSuccess(t('cospend', 'Mapping updated'))
+						emit('auto-category-mappings-changed')
+					})
+					.catch((error) => {
+						console.error('Failed to update mapping', error)
+						showError(getErrorMessage(error, t('cospend', 'Failed to update mapping')))
+					})
+			} else {
+				network.createAutoCategoryMapping(this.projectId, title, catId)
+					.then((response) => {
+						this.autoMappings.push({
+							id: response.data.ocs.data,
+							project_id: this.projectId,
+							bill_title: title,
+							category_id: catId,
+						})
+						cachedMappings = null
+						showSuccess(t('cospend', 'Mapping added'))
+						emit('auto-category-mappings-changed')
+					})
+					.catch((error) => {
+						console.error('Failed to create mapping', error)
+						showError(getErrorMessage(error, t('cospend', 'Failed to add mapping')))
+					})
+			}
+			this.saveMappingChecked = false
 		},
 		getPersonalParts() {
 			const result = {}
@@ -1685,6 +1802,47 @@ export default {
 					t('cospend', 'Failed to generate share link to file')
 					+ ': ' + (error.response?.data?.ocs?.meta?.message || error.response?.data?.ocs?.data?.message || error.response?.request?.responseText),
 				)
+			})
+		},
+		onWhatBlur() {
+			if (this.project.auto_categorization !== '1') {
+				return
+			}
+			if (!OCA.Cospend.state.auto_categorization_enabled) {
+				return
+			}
+			if (this.userTouchedCategory) {
+				return
+			}
+			if (this.myBill.categoryid !== 0) {
+				return
+			}
+			const title = (this.myBill.what || '').trim().toLowerCase()
+			if (title === '') {
+				return
+			}
+			const match = this.autoMappings.find((m) => m.bill_title.toLowerCase() === title)
+			if (match && match.category_id) {
+				this.myBill.categoryid = match.category_id
+				this.onBillEdited(null, false)
+			}
+		},
+		fetchAutoMappings() {
+			// there is no public API for mappings, public link sessions
+			// still get server-side auto-categorisation on bill creation
+			if (this.pageIsPublic || !OCA.Cospend.state.auto_categorization_enabled) {
+				return
+			}
+			if (cachedProjectId === this.projectId && cachedMappings) {
+				this.autoMappings = cachedMappings
+				return
+			}
+			network.getAutoCategoryMappings(this.projectId).then((response) => {
+				this.autoMappings = response.data.ocs.data
+				cachedMappings = response.data.ocs.data
+				cachedProjectId = this.projectId
+			}).catch((error) => {
+				console.error('Failed to fetch auto-category mappings', error)
 			})
 		},
 		onDuplicate() {
@@ -1831,6 +1989,10 @@ button {
 	display: flex;
 	justify-content: end;
 	margin: 8px 0 8px 0;
+}
+
+.save-mapping-row {
+	margin-left: 28px;
 }
 
 .bill-field {

--- a/src/components/AutoCategoryMappingsSettings.vue
+++ b/src/components/AutoCategoryMappingsSettings.vue
@@ -1,0 +1,942 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="auto-category-mappings-settings">
+		<h3>
+			<ShapeIcon class="icon" :size="20" />
+			<span class="tcontent">
+				{{ t('cospend', 'Auto-category mappings') }}
+			</span>
+			<NcButton
+				:title="t('cospend', 'How it works')"
+				:aria-label="t('cospend', 'How it works')"
+				@click="showHelp = !showHelp">
+				<template #icon>
+					<InformationOutlineIcon :size="16" />
+				</template>
+			</NcButton>
+			<NcActions v-if="maintainerAccess">
+				<NcActionButton :close-after-click="true" @click="openProjectDialog('copy-all')">
+					<template #icon>
+						<ContentCopyIcon :size="16" />
+					</template>
+					{{ t('cospend', 'Copy all mappings to another project') }}
+				</NcActionButton>
+				<NcActionButton :close-after-click="true" @click="openProjectDialog('import')">
+					<template #icon>
+						<ImportIcon :size="16" />
+					</template>
+					{{ t('cospend', 'Import mappings from another project') }}
+				</NcActionButton>
+			</NcActions>
+		</h3>
+		<div v-if="showHelp" class="help-card">
+			<p>{{ t('cospend', 'When you create or edit a bill, the title is checked against these mappings. If a match is found, the category is assigned automatically.') }}</p>
+		</div>
+		<div v-if="maintainerAccess" class="add-mapping">
+			<NcTextField
+				v-model="newMappingTitle"
+				class="title-input"
+				:aria-label="t('cospend', 'Bill title')"
+				:placeholder="t('cospend', 'Bill title')"
+				:disabled="adding"
+				@keyup.enter="addMapping" />
+			<NcSelect
+				v-model="newMappingCategory"
+				class="category-select"
+				:placeholder="t('cospend', 'Category')"
+				:aria-label-combobox="t('cospend', 'Category')"
+				:options="categoryOptions"
+				label="name"
+				:no-wrap="true"
+				:clearable="false"
+				:disabled="adding" />
+			<NcButton
+				:title="t('cospend', 'Add mapping')"
+				:aria-label="t('cospend', 'Add mapping')"
+				:disabled="!canAddMapping || adding"
+				@click="addMapping">
+				<template #icon>
+					<NcLoadingIcon v-if="adding" />
+					<PlusIcon v-else :size="20" />
+				</template>
+			</NcButton>
+		</div>
+		<div v-if="duplicateWarning" class="duplicate-warning">
+			{{ t('cospend', 'A mapping with this title already exists') }}
+		</div>
+		<div v-if="loadingMappings" class="loading-mappings">
+			<NcLoadingIcon :size="20" />
+		</div>
+		<div v-else-if="mappings.length === 0" class="no-mappings">
+			{{ t('cospend', 'No mappings yet') }}
+			<NcButton v-if="maintainerAccess" class="focus-add-btn" @click="focusAddMapping">
+				<template #icon>
+					<PlusIcon :size="16" />
+				</template>
+				{{ t('cospend', 'Add mapping') }}
+			</NcButton>
+		</div>
+		<div v-if="mappings.length >= searchThreshold" class="sort-bar">
+			<NcTextField
+				v-model="searchQuery"
+				:aria-label="t('cospend', 'Search')"
+				:placeholder="t('cospend', 'Search')"
+				class="search-input" />
+			<NcSelect
+				v-model="sortMode"
+				:title="t('cospend', 'Sort')"
+				:aria-label-combobox="t('cospend', 'Sort')"
+				:options="sortOptions"
+				label="label"
+				:clearable="false"
+				:no-wrap="true"
+				class="sort-select" />
+		</div>
+		<div v-for="mapping in paginatedMappings"
+			:key="mapping.id"
+			class="mapping-item"
+			:class="{ editing: editingId === mapping.id }">
+			<div v-if="mapping.category_id === null" class="mapping-invalid-badge" :title="t('cospend', 'Category was deleted')">
+				<AlertIcon :size="16" />
+			</div>
+			<template v-if="editingId !== mapping.id">
+				<span
+					class="mapping-title"
+					:class="{ 'mapping-title-invalid': mapping.category_id === null }"
+					:title="titleDisplay(mapping.bill_title)">{{ titleDisplay(mapping.bill_title) }}</span>
+				<span class="mapping-arrow">→</span>
+				<span class="mapping-category" :class="{ 'mapping-category-invalid': mapping.category_id === null }">{{ categoryDisplay(mapping.category_id) }}</span>
+				<NcActions v-if="maintainerAccess" class="mapping-actions">
+					<NcActionButton :close-after-click="true" @click="startEdit(mapping)">
+						<template #icon>
+							<PencilIcon :size="16" />
+						</template>
+						{{ t('cospend', 'Edit') }}
+					</NcActionButton>
+					<NcActionButton :close-after-click="true" @click="openProjectDialog('copy-single', mapping)">
+						<template #icon>
+							<ContentCopyIcon :size="16" />
+						</template>
+						{{ t('cospend', 'Copy to project…') }}
+					</NcActionButton>
+					<NcActionButton :close-after-click="true" @click="confirmDelete(mapping.id)">
+						<template #icon>
+							<DeleteIcon :size="16" />
+						</template>
+						{{ t('cospend', 'Delete') }}
+					</NcActionButton>
+				</NcActions>
+			</template>
+			<template v-else>
+				<NcTextField
+					v-model="editTitle"
+					class="title-input"
+					:aria-label="t('cospend', 'Title')"
+					:placeholder="t('cospend', 'Title')"
+					:disabled="saving"
+					@keyup.enter="saveEdit(mapping)"
+					@keyup.escape="cancelEdit" />
+				<NcSelect
+					v-model="editCategory"
+					class="category-select"
+					:placeholder="t('cospend', 'Category')"
+					:aria-label-combobox="t('cospend', 'Category')"
+					:options="categoryOptions"
+					label="name"
+					:no-wrap="true"
+					:clearable="false"
+					:disabled="saving" />
+				<div class="edit-buttons">
+					<NcButton
+						:title="t('cospend', 'Save')"
+						:aria-label="t('cospend', 'Save')"
+						:disabled="saving"
+						@click="saveEdit(mapping)">
+						<template #icon>
+							<NcLoadingIcon v-if="saving" />
+							<CheckIcon v-else :size="16" />
+						</template>
+					</NcButton>
+					<NcButton
+						:title="t('cospend', 'Cancel')"
+						:aria-label="t('cospend', 'Cancel')"
+						:disabled="saving"
+						@click="cancelEdit">
+						<template #icon>
+							<CloseIcon :size="16" />
+						</template>
+					</NcButton>
+				</div>
+			</template>
+		</div>
+		<div v-if="filteredMappings.length > minPageSize" class="mappings-footer">
+			<span class="mapping-count">{{ filteredMappings.length }} {{ t('cospend', 'mapping(s)') }}</span>
+			<div class="pagination-bar">
+				<NcSelect
+					v-model="pageSize"
+					:title="t('cospend', 'Mappings per page')"
+					:aria-label-combobox="t('cospend', 'Mappings per page')"
+					:options="pageSizeOptions"
+					label="label"
+					:clearable="false"
+					:no-wrap="true"
+					class="page-size-select" />
+				<span class="page-info">{{ currentPage }} / {{ totalPages }}</span>
+				<NcButton
+					:disabled="currentPage <= 1"
+					:aria-label="t('cospend', 'Previous page')"
+					@click="prevPage">
+					<template #icon>
+						<ChevronLeftIcon :size="16" />
+					</template>
+				</NcButton>
+				<NcButton
+					:disabled="currentPage >= totalPages"
+					:aria-label="t('cospend', 'Next page')"
+					@click="nextPage">
+					<template #icon>
+						<ChevronRightIcon :size="16" />
+					</template>
+				</NcButton>
+			</div>
+		</div>
+		<div v-if="maintainerAccess && mappings.length > 0" class="auto-categorize-actions">
+			<NcButton
+				:disabled="autoCategorizing"
+				@click="autoCategorizeNow">
+				<template #icon>
+					<NcLoadingIcon v-if="autoCategorizing" />
+					<AutoFixIcon v-else :size="20" />
+				</template>
+				{{ t('cospend', 'Apply to existing bills') }}
+			</NcButton>
+		</div>
+		<NcDialog v-model:open="showDeleteDialog"
+			:name="t('cospend', 'Delete mapping')"
+			:message="t('cospend', 'Are you sure you want to delete this mapping?')">
+			<NcCheckboxRadioSwitch v-model="skipDeleteConfirm">
+				{{ t('cospend', "Don't ask me again") }}
+			</NcCheckboxRadioSwitch>
+			<template #actions>
+				<NcButton @click="showDeleteDialog = false">
+					{{ t('cospend', 'Cancel') }}
+				</NcButton>
+				<NcButton variant="warning" @click="doDeleteMapping(deleteTargetId)">
+					<template #icon>
+						<DeleteIcon :size="16" />
+					</template>
+					{{ t('cospend', 'Delete') }}
+				</NcButton>
+			</template>
+		</NcDialog>
+		<NcDialog v-model:open="projectDialogOpen"
+			:name="projectDialogTitle">
+			<div class="project-dialog-content">
+				<p class="project-dialog-description">
+					{{ projectDialogDescription }}
+				</p>
+				<NcSelect
+					v-model="projectDialogTarget"
+					class="project-select"
+					:placeholder="projectDialogSelectLabel"
+					:aria-label-combobox="projectDialogSelectLabel"
+					:options="otherProjects"
+					label="name"
+					:no-wrap="true"
+					:clearable="false"
+					:disabled="projectDialogLoading" />
+				<div v-if="projectDialogResult" class="copy-result">
+					{{ projectDialogResult }}
+					<div v-if="projectDialogErrors.length > 0" class="copy-errors">
+						<div v-for="(err, i) in projectDialogErrors" :key="i" class="copy-error-item">
+							{{ errorDisplay(err) }}
+						</div>
+					</div>
+				</div>
+			</div>
+			<template #actions>
+				<NcButton :disabled="projectDialogLoading" @click="projectDialogOpen = false">
+					{{ projectDialogResult ? t('cospend', 'Close') : t('cospend', 'Cancel') }}
+				</NcButton>
+				<NcButton
+					variant="primary"
+					:disabled="!projectDialogTarget || projectDialogLoading"
+					@click="doProjectDialogAction">
+					<template #icon>
+						<NcLoadingIcon v-if="projectDialogLoading" />
+						<ImportIcon v-else-if="projectDialogMode === 'import'" :size="16" />
+						<ContentCopyIcon v-else :size="16" />
+					</template>
+					{{ projectDialogActionLabel }}
+				</NcButton>
+			</template>
+		</NcDialog>
+	</div>
+</template>
+
+<script>
+import ShapeIcon from 'vue-material-design-icons/Shape.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
+import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import CheckIcon from 'vue-material-design-icons/Check.vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+import AutoFixIcon from 'vue-material-design-icons/AutoFix.vue'
+import ContentCopyIcon from 'vue-material-design-icons/ContentCopy.vue'
+import ImportIcon from 'vue-material-design-icons/Import.vue'
+import AlertIcon from 'vue-material-design-icons/AlertCircleOutline.vue'
+import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import InformationOutlineIcon from 'vue-material-design-icons/InformationOutline.vue'
+
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+import NcSelect from '@nextcloud/vue/components/NcSelect'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+import { showSuccess, showError } from '@nextcloud/dialogs'
+import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus'
+import { getCategory, getErrorMessage, decodeHtmlEntities } from '../utils.js'
+import * as network from '../network.js'
+import * as constants from '../constants.js'
+
+export default {
+	name: 'AutoCategoryMappingsSettings',
+
+	components: {
+		ShapeIcon,
+		PlusIcon,
+		PencilIcon,
+		DeleteIcon,
+		CheckIcon,
+		CloseIcon,
+		AutoFixIcon,
+		ContentCopyIcon,
+		ImportIcon,
+		AlertIcon,
+		ChevronLeftIcon,
+		ChevronRightIcon,
+		InformationOutlineIcon,
+		NcActions,
+		NcActionButton,
+		NcButton,
+		NcTextField,
+		NcSelect,
+		NcLoadingIcon,
+		NcDialog,
+		NcCheckboxRadioSwitch,
+	},
+
+	props: {
+		project: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			cospend: OCA.Cospend.state,
+			mappings: [],
+			newMappingTitle: '',
+			newMappingCategory: null,
+			editingId: null,
+			editTitle: '',
+			editCategory: null,
+			loadingMappings: false,
+			adding: false,
+			saving: false,
+			autoCategorizing: false,
+			// search/sort and pagination only appear for larger lists
+			searchThreshold: 8,
+			minPageSize: 5,
+			projectDialogOpen: false,
+			projectDialogMode: null,
+			projectDialogMapping: null,
+			projectDialogTarget: null,
+			projectDialogLoading: false,
+			projectDialogResult: '',
+			projectDialogErrors: [],
+			sortMode: { id: 'alpha-asc', label: 'A→Z' },
+			searchQuery: '',
+			showDeleteDialog: false,
+			deleteTargetId: null,
+			skipDeleteConfirm: false,
+			pageSize: { id: 10, label: '10' },
+			currentPage: 1,
+			showHelp: false,
+		}
+	},
+
+	computed: {
+		projectId() {
+			return this.project.id
+		},
+		maintainerAccess() {
+			return this.project.myaccesslevel >= constants.ACCESS.MAINTENER
+		},
+		categoryOptions() {
+			const items = [{
+				name: t('cospend', 'None'),
+				id: 0,
+			}]
+			const allCategories = Object.values(this.cospend.projects[this.projectId].categories || {})
+			allCategories.sort((a, b) => a.name.localeCompare(b.name))
+			items.push(...allCategories.map((c) => ({
+				name: (c.icon || '') + ' ' + c.name,
+				id: c.id,
+			})))
+			return items
+		},
+		canAddMapping() {
+			return this.newMappingTitle.trim() !== '' && this.newMappingCategory !== null
+		},
+		sortModeValue() {
+			return this.sortMode.id
+		},
+		sortOptions() {
+			return [
+				{ id: 'alpha-asc', label: 'A→Z' },
+				{ id: 'alpha-desc', label: 'Z→A' },
+				{ id: 'date-desc', label: t('cospend', 'Newest first') },
+				{ id: 'date-asc', label: t('cospend', 'Oldest first') },
+			]
+		},
+		pageSizeOptions() {
+			return [
+				{ id: 5, label: '5' },
+				{ id: 10, label: '10' },
+				{ id: 25, label: '25' },
+				{ id: 0, label: t('cospend', 'All') },
+			]
+		},
+		sortedMappings() {
+			const sorted = [...this.mappings]
+			const mode = this.sortModeValue
+			switch (mode) {
+			case 'alpha-asc':
+				sorted.sort((a, b) => a.bill_title.localeCompare(b.bill_title))
+				break
+			case 'alpha-desc':
+				sorted.sort((a, b) => b.bill_title.localeCompare(a.bill_title))
+				break
+			case 'date-asc':
+				sorted.sort((a, b) => (a.created_at || a.last_changed) - (b.created_at || b.last_changed))
+				break
+			case 'date-desc':
+				sorted.sort((a, b) => (b.created_at || b.last_changed) - (a.created_at || a.last_changed))
+				break
+			}
+			return sorted
+		},
+		filteredMappings() {
+			const q = this.searchQuery.trim().toLowerCase()
+			if (!q) {
+				return this.sortedMappings
+			}
+			return this.sortedMappings.filter((m) =>
+				m.bill_title.toLowerCase().includes(q)
+				|| this.categoryDisplay(m.category_id).toLowerCase().includes(q),
+			)
+		},
+		totalPages() {
+			const size = this.pageSize.id
+			if (size === 0) {
+				return 1
+			}
+			return Math.ceil(this.filteredMappings.length / size) || 1
+		},
+		paginatedMappings() {
+			const size = this.pageSize.id
+			if (size === 0) {
+				return this.filteredMappings
+			}
+			const start = (this.currentPage - 1) * size
+			return this.filteredMappings.slice(start, start + size)
+		},
+		duplicateWarning() {
+			const title = this.newMappingTitle.trim().toLowerCase()
+			if (!title) {
+				return false
+			}
+			return this.mappings.some((m) => m.bill_title.toLowerCase() === title)
+		},
+		otherProjects() {
+			const allProjects = Object.values(this.cospend.projects || {})
+			return allProjects
+				.filter((p) => p.id !== this.projectId)
+				.sort((a, b) => a.name.localeCompare(b.name))
+				.map((p) => ({
+					id: p.id,
+					name: p.name,
+				}))
+		},
+		projectDialogTitle() {
+			if (this.projectDialogMode === 'import') {
+				return t('cospend', 'Import mappings')
+			}
+			if (this.projectDialogMode === 'copy-single') {
+				return t('cospend', 'Copy mapping')
+			}
+			return t('cospend', 'Copy all mappings')
+		},
+		projectDialogDescription() {
+			if (this.projectDialogMode === 'import') {
+				return t('cospend', 'Mappings of the selected project are imported into this one. Categories are matched by name.')
+			}
+			if (this.projectDialogMode === 'copy-single') {
+				return t('cospend', 'The mapping "{title}" is copied to the selected project. Categories are matched by name.', { title: this.titleDisplay(this.projectDialogMapping?.bill_title ?? '') })
+			}
+			return t('cospend', 'All mappings are copied to the selected project. Categories are matched by name.')
+		},
+		projectDialogSelectLabel() {
+			return this.projectDialogMode === 'import'
+				? t('cospend', 'Source project')
+				: t('cospend', 'Target project')
+		},
+		projectDialogActionLabel() {
+			return this.projectDialogMode === 'import'
+				? t('cospend', 'Import')
+				: t('cospend', 'Copy')
+		},
+	},
+
+	watch: {
+		projectId() {
+			this.fetchMappings()
+		},
+		mappings() {
+			this.currentPage = 1
+		},
+		searchQuery() {
+			this.currentPage = 1
+		},
+		'sortMode.id'() {
+			this.currentPage = 1
+		},
+	},
+
+	mounted() {
+		this.fetchMappings()
+		// re-fetch when a mapping is saved from the bill form checkbox
+		this._onMappingsChanged = () => {
+			this.fetchMappings()
+		}
+		subscribe('auto-category-mappings-changed', this._onMappingsChanged)
+	},
+
+	beforeUnmount() {
+		unsubscribe('auto-category-mappings-changed', this._onMappingsChanged)
+	},
+
+	methods: {
+		fetchMappings() {
+			this.loadingMappings = true
+			network.getAutoCategoryMappings(this.projectId).then((response) => {
+				this.mappings = response.data.ocs.data
+			}).catch((error) => {
+				console.error('Failed to fetch auto-category mappings', error)
+				showError(getErrorMessage(error, t('cospend', 'Failed to fetch mappings')))
+			}).then(() => {
+				this.loadingMappings = false
+			})
+		},
+		categoryDisplay(categoryId) {
+			if (categoryId === null) {
+				return t('cospend', 'Deleted category')
+			}
+			const cat = getCategory(this.projectId, categoryId)
+			return (cat.icon || '') + ' ' + cat.name
+		},
+		titleDisplay(title) {
+			return decodeHtmlEntities(title)
+		},
+		errorDisplay(err) {
+			return decodeHtmlEntities(err)
+		},
+		addMapping() {
+			if (!this.canAddMapping || this.adding) {
+				return
+			}
+			this.adding = true
+			const title = this.newMappingTitle.trim()
+			const catId = this.newMappingCategory.id
+			network.createAutoCategoryMapping(this.projectId, title, catId).then((response) => {
+				const newId = response.data.ocs.data
+				this.mappings.push({
+					id: newId,
+					project_id: this.projectId,
+					bill_title: title,
+					category_id: catId,
+				})
+				this.newMappingTitle = ''
+				this.newMappingCategory = null
+				showSuccess(t('cospend', 'Mapping added'))
+				emit('auto-category-mappings-changed')
+			}).catch((error) => {
+				console.error('Failed to create mapping', error)
+				showError(getErrorMessage(error, t('cospend', 'Failed to add mapping')))
+			}).then(() => {
+				this.adding = false
+			})
+		},
+		startEdit(mapping) {
+			this.editingId = mapping.id
+			this.editTitle = mapping.bill_title
+			const cat = getCategory(this.projectId, mapping.category_id)
+			this.editCategory = { id: cat.id, name: cat.icon + ' ' + cat.name }
+		},
+		cancelEdit() {
+			this.editingId = null
+			this.editTitle = ''
+			this.editCategory = null
+		},
+		saveEdit(mapping) {
+			if (this.saving) {
+				return
+			}
+			this.saving = true
+			const title = this.editTitle.trim()
+			const catId = this.editCategory.id
+			network.editAutoCategoryMapping(this.projectId, mapping.id, title, catId).then(() => {
+				mapping.bill_title = title
+				mapping.category_id = catId
+				this.cancelEdit()
+				showSuccess(t('cospend', 'Mapping updated'))
+				emit('auto-category-mappings-changed')
+			}).catch((error) => {
+				console.error('Failed to update mapping', error)
+				showError(getErrorMessage(error, t('cospend', 'Failed to update mapping')))
+			}).then(() => {
+				this.saving = false
+			})
+		},
+		confirmDelete(mappingId) {
+			this.deleteTargetId = mappingId
+			if (this.skipDeleteConfirm) {
+				this.doDeleteMapping()
+				return
+			}
+			this.showDeleteDialog = true
+		},
+		doDeleteMapping(mappingId) {
+			const id = mappingId ?? this.deleteTargetId
+			if (!id) return
+			network.deleteAutoCategoryMapping(this.projectId, id).then(() => {
+				this.mappings = this.mappings.filter((m) => m.id !== id)
+				showSuccess(t('cospend', 'Mapping deleted'))
+				emit('auto-category-mappings-changed')
+			}).catch((error) => {
+				console.error('Failed to delete mapping', error)
+				showError(getErrorMessage(error, t('cospend', 'Failed to delete mapping')))
+			}).then(() => {
+				this.showDeleteDialog = false
+				this.deleteTargetId = null
+			})
+		},
+		focusAddMapping() {
+			const input = this.$el.querySelector('.add-mapping input')
+			if (input) input.focus()
+		},
+		prevPage() {
+			if (this.currentPage > 1) {
+				this.currentPage--
+			}
+		},
+		nextPage() {
+			if (this.currentPage < this.totalPages) {
+				this.currentPage++
+			}
+		},
+		formatCopyResult(result) {
+			const imported = result.imported
+			const skipped = result.skipped
+			let msg = t('cospend', '{count} mapping(s) imported', { count: imported })
+			if (skipped > 0) {
+				msg += ', ' + t('cospend', '{count} skipped', { count: skipped })
+			}
+			return msg
+		},
+		openProjectDialog(mode, mapping = null) {
+			this.projectDialogMode = mode
+			this.projectDialogMapping = mapping
+			this.projectDialogTarget = null
+			this.projectDialogResult = ''
+			this.projectDialogErrors = []
+			this.projectDialogOpen = true
+		},
+		doProjectDialogAction() {
+			if (!this.projectDialogTarget || this.projectDialogLoading) {
+				return
+			}
+			this.projectDialogLoading = true
+			this.projectDialogResult = ''
+			this.projectDialogErrors = []
+			const otherProjectId = this.projectDialogTarget.id
+			let request
+			if (this.projectDialogMode === 'import') {
+				request = network.importAutoCategoryMappings(this.projectId, otherProjectId)
+			} else if (this.projectDialogMode === 'copy-single') {
+				request = network.copyAutoCategoryMappings(this.projectId, otherProjectId, this.projectDialogMapping.id)
+			} else {
+				request = network.copyAutoCategoryMappings(this.projectId, otherProjectId)
+			}
+			request.then((response) => {
+				const result = response.data.ocs.data
+				this.projectDialogResult = this.formatCopyResult(result)
+				this.projectDialogErrors = result.errors || []
+				if (this.projectDialogMode === 'import' && result.imported > 0) {
+					emit('auto-category-mappings-changed')
+				}
+			}).catch((error) => {
+				console.error('Failed to copy/import mappings', error)
+				showError(getErrorMessage(error, t('cospend', 'Failed to copy mappings')))
+			}).then(() => {
+				this.projectDialogLoading = false
+			})
+		},
+		autoCategorizeNow() {
+			if (this.autoCategorizing) {
+				return
+			}
+			this.autoCategorizing = true
+			network.autoCategorizeProject(this.projectId).then((response) => {
+				const count = response.data.ocs.data
+				showSuccess(t('cospend', '{count} bill(s) categorised', { count }))
+				if (count > 0) {
+					emit('reload-bills')
+				}
+			}).catch((error) => {
+				console.error('Failed to auto-categorize', error)
+				showError(getErrorMessage(error, t('cospend', 'Failed to auto-categorize')))
+			}).then(() => {
+				this.autoCategorizing = false
+			})
+		},
+	},
+}
+</script>
+
+<style scoped lang="scss">
+.auto-category-mappings-settings {
+	// keep selects vertically centered in their flex rows
+	:deep(.v-select.select) {
+		margin: 0;
+	}
+
+	h3 {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-top: 12px;
+
+		.tcontent {
+			flex-grow: 1;
+		}
+	}
+
+	.add-mapping {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		margin: 8px 0;
+	}
+
+	.title-input {
+		flex: 1 1 auto;
+		min-width: 100px;
+	}
+
+	.category-select {
+		flex: 1 1 auto;
+		min-width: 130px;
+	}
+
+	.duplicate-warning {
+		color: var(--color-main-text);
+		font-size: 0.9em;
+		font-weight: 600;
+		padding: 6px 8px;
+		margin: 4px 0;
+		background: var(--color-background-dark);
+		border-radius: var(--border-radius);
+		border-left: 4px solid var(--color-error);
+	}
+
+	.loading-mappings {
+		display: flex;
+		justify-content: center;
+		padding: 8px;
+	}
+
+	.no-mappings {
+		color: var(--color-text-lighter);
+		padding: 4px 0;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.help-card {
+		background: var(--color-background-dark);
+		border-radius: var(--border-radius);
+		padding: 8px;
+		margin: 4px 0;
+		font-size: 0.9em;
+		color: var(--color-text-lighter);
+	}
+
+	.sort-bar {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 4px 0;
+	}
+
+	.search-input {
+		flex: 1;
+		min-width: 100px;
+	}
+
+	.sort-select {
+		min-width: 120px;
+	}
+
+	.mapping-count {
+		color: var(--color-text-lighter);
+		font-size: 0.85em;
+		white-space: nowrap;
+	}
+
+	.mappings-footer {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		padding: 8px 0;
+	}
+
+	.pagination-bar {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.page-size-select {
+		min-width: 70px;
+	}
+
+	.page-info {
+		color: var(--color-text-lighter);
+		font-size: 0.85em;
+	}
+
+	.mapping-item {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 4px 0;
+
+		// the edit form needs more room than a display row
+		&.editing {
+			flex-wrap: wrap;
+		}
+
+		.mapping-invalid-badge {
+			color: var(--color-warning);
+			display: flex;
+			align-items: center;
+		}
+
+		.mapping-title {
+			font-weight: bold;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			min-width: 60px;
+		}
+
+		.mapping-title-invalid {
+			text-decoration: line-through;
+			color: var(--color-text-lighter);
+		}
+
+		.mapping-arrow {
+			color: var(--color-text-lighter);
+		}
+
+		.mapping-category {
+			flex-grow: 1;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.mapping-category-invalid {
+			text-decoration: line-through;
+			color: var(--color-warning);
+		}
+
+		.edit-buttons {
+			display: flex;
+			align-items: center;
+			gap: 2px;
+			white-space: nowrap;
+		}
+	}
+
+	.auto-categorize-actions {
+		margin-top: 8px;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+	}
+}
+
+.project-dialog-content {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 0 4px 8px 4px;
+
+	.project-dialog-description {
+		color: var(--color-text-lighter);
+	}
+
+	.project-select {
+		width: 100%;
+	}
+
+	.copy-result {
+		color: var(--color-main-text);
+		font-size: 0.95em;
+		font-weight: 600;
+		padding: 8px 10px;
+		background: var(--color-main-background);
+		border-radius: var(--border-radius);
+		border: 1px solid var(--color-success);
+		border-left: 4px solid var(--color-success);
+	}
+
+	.copy-errors {
+		margin-top: 4px;
+	}
+
+	.copy-error-item {
+		color: var(--color-main-text);
+		font-size: 0.9em;
+		font-weight: 600;
+		padding: 4px 8px;
+		margin: 2px 0;
+		background: var(--color-background-dark);
+		border-radius: var(--border-radius);
+		border-left: 3px solid var(--color-error);
+	}
+}
+</style>

--- a/src/components/SettingsTabSidebar.vue
+++ b/src/components/SettingsTabSidebar.vue
@@ -28,6 +28,14 @@
 					{{ t('cospend', 'Allow bill deletion') }}
 				</NcFormBoxSwitch>
 			</div>
+			<div v-if="adminAccess && cospend.auto_categorization_enabled" class="auto-categorization-line">
+				<NcFormBoxSwitch
+					id="auto-categorization"
+					:model-value="project.auto_categorization === '1'"
+					@update:model-value="onAutoCategorizationChange">
+					{{ t('cospend', 'Auto-categorise bills') }}
+				</NcFormBoxSwitch>
+			</div>
 			<NcSelect
 				:model-value="selectedAutoExportOption"
 				:input-label="t('cospend', 'Automatic export')"
@@ -494,6 +502,10 @@ export default {
 		},
 		onDisableDeletionChange(checked) {
 			this.cospend.projects[this.projectId].deletiondisabled = !checked
+			this.$emit('project-edited', this.projectId)
+		},
+		onAutoCategorizationChange(checked) {
+			this.cospend.projects[this.projectId].auto_categorization = checked ? '1' : '0'
 			this.$emit('project-edited', this.projectId)
 		},
 		onMultiselectEnterPressed(elem) {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -83,6 +83,11 @@
 				type="category"
 				@project-edited="onProjectEdited"
 				@element-deleted="onCategoryDeleted" />
+			<!-- mapping management is maintainer-level (like the backend endpoints)
+				but hidden on public link pages: there is no public API for mappings -->
+			<AutoCategoryMappingsSettings
+				v-if="editionAccess && !pageIsPublic && autoCategorizationEnabled && project.auto_categorization === '1'"
+				:project="project" />
 		</NcAppSidebarTab>
 		<NcAppSidebarTab
 			id="paymentmodes"
@@ -129,6 +134,8 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcAppSidebar from '@nextcloud/vue/components/NcAppSidebar'
 import NcAppSidebarTab from '@nextcloud/vue/components/NcAppSidebarTab'
 
+import { defineAsyncComponent } from 'vue'
+
 import SharingTabSidebar from './SharingTabSidebar.vue'
 import SettingsTabSidebar from './SettingsTabSidebar.vue'
 import CategoryOrPmManagement from '../CategoryOrPmManagement.vue'
@@ -148,6 +155,7 @@ export default {
 		SharingTabSidebar,
 		SettingsTabSidebar,
 		CategoryOrPmManagement,
+		AutoCategoryMappingsSettings: defineAsyncComponent(() => import('./AutoCategoryMappingsSettings.vue')),
 		CurrencyManagement,
 		ActivityTabSidebar,
 		ShapeIcon,
@@ -186,6 +194,7 @@ export default {
 			tmpName: '',
 			pageIsPublic: OCA.Cospend.state.pageIsPublic,
 			activityEnabled: OCA.Cospend.state.activity_enabled,
+			autoCategorizationEnabled: OCA.Cospend.state.auto_categorization_enabled,
 		}
 	},
 	computed: {

--- a/src/network.js
+++ b/src/network.js
@@ -146,6 +146,7 @@ export function editProject(project, password) {
 		categorySort: project.categorysort,
 		paymentModeSort: project.paymentmodesort,
 		archivedTs: project.archived_ts,
+		autoCategorization: project.auto_categorization,
 	}
 	const url = OCA.Cospend.state.pageIsPublic
 		? generateOcsUrl('/apps/cospend/api/v1/public/projects/{projectId}/{password}', { projectId: OCA.Cospend.state.projectid, password: OCA.Cospend.state.password })
@@ -606,6 +607,128 @@ export function rejectInvitation(invitationId) {
 	return axios.delete(url, req)
 }
 
+/**
+ * Fetch all auto-category mappings for a project
+ *
+ * @param {string} projectId - The project ID
+ * @return {Promise<import('axios').AxiosResponse<{ocs: {data: AutoCategoryMapping[]}}>>}
+ */
+export function getAutoCategoryMappings(projectId) {
+	const url = generateOcsUrl('/apps/cospend/api/v1/projects/{projectId}/auto-mappings', { projectId })
+	return axios.get(url)
+}
+
+/**
+ * Create a new auto-category mapping
+ *
+ * @param {string} projectId - The project ID
+ * @param {string} billTitle - The bill title to match
+ * @param {number} categoryId - The category ID to assign
+ * @return {Promise<import('axios').AxiosResponse<{ocs: {data: number}}>>} Resolves with the new mapping ID
+ */
+export function createAutoCategoryMapping(projectId, billTitle, categoryId) {
+	const req = {
+		billTitle,
+		categoryId,
+	}
+	const url = generateOcsUrl('/apps/cospend/api/v1/projects/{projectId}/auto-mappings', { projectId })
+	return axios.post(url, req)
+}
+
+/**
+ * Edit an existing auto-category mapping
+ *
+ * @param {string} projectId - The project ID
+ * @param {number} mappingId - The mapping ID
+ * @param {string} billTitle - The new bill title
+ * @param {number} categoryId - The new category ID
+ * @return {Promise<import('axios').AxiosResponse<{ocs: {data: AutoCategoryMapping}}>>}
+ */
+export function editAutoCategoryMapping(projectId, mappingId, billTitle, categoryId) {
+	const req = {
+		billTitle,
+		categoryId,
+	}
+	const url = generateOcsUrl('/apps/cospend/api/v1/projects/{projectId}/auto-mappings/{mappingId}', { projectId, mappingId })
+	return axios.put(url, req)
+}
+
+/**
+ * Delete an auto-category mapping
+ *
+ * @param {string} projectId - The project ID
+ * @param {number} mappingId - The mapping ID
+ * @return {Promise<import('axios').AxiosResponse>}
+ */
+export function deleteAutoCategoryMapping(projectId, mappingId) {
+	const url = generateOcsUrl('/apps/cospend/api/v1/projects/{projectId}/auto-mappings/{mappingId}', { projectId, mappingId })
+	return axios.delete(url)
+}
+
+/**
+ * Auto-categorise all bills in a project
+ *
+ * @param {string} projectId - The project ID
+ * @return {Promise<import('axios').AxiosResponse<{ocs: {data: number}}>>} Resolves with the count of categorised bills
+ */
+export function autoCategorizeProject(projectId) {
+	const url = generateOcsUrl('/apps/cospend/api/v1/projects/{projectId}/auto-categorize', { projectId })
+	return axios.post(url)
+}
+
+/**
+ * Auto-categorise bills in all projects (admin only)
+ *
+ * @return {Promise<import('axios').AxiosResponse<{ocs: {data: number}}>>} Resolves with total count of categorised bills
+ */
+export function autoCategorizeAll() {
+	const url = generateOcsUrl('/apps/cospend/api/v1/auto-categorize')
+	return axios.post(url)
+}
+
+/**
+ * Copy auto-category mappings from one project to another
+ *
+ * @param {string} projectId - Source project ID
+ * @param {string} targetProjectId - Target project ID
+ * @param {number|null} mappingId - Restrict the copy to this single mapping
+ * @return {Promise<import('axios').AxiosResponse<{ocs: {data: CopyImportResult}}>>}
+ */
+export function copyAutoCategoryMappings(projectId, targetProjectId, mappingId = null) {
+	const req = mappingId === null ? {} : { mappingId }
+	const url = generateOcsUrl('/apps/cospend/api/v1/projects/{projectId}/auto-mappings/copy-to/{targetProjectId}', { projectId, targetProjectId })
+	return axios.post(url, req)
+}
+
+/**
+ * Import auto-category mappings from another project
+ *
+ * @param {string} projectId - Target project ID
+ * @param {string} sourceProjectId - Source project ID
+ * @return {Promise<import('axios').AxiosResponse<{ocs: {data: CopyImportResult}}>>}
+ */
+export function importAutoCategoryMappings(projectId, sourceProjectId) {
+	const url = generateOcsUrl('/apps/cospend/api/v1/projects/{projectId}/auto-mappings/import-from/{sourceProjectId}', { projectId, sourceProjectId })
+	return axios.post(url)
+}
+
 export function getRemoteAvatarUrl(cloudId) {
 	return generateOcsUrl('/apps/cospend/api/v1/remote/avatar/64?cloudId={cloudId}', { cloudId })
 }
+
+/**
+ * @typedef {object} AutoCategoryMapping
+ * @property {number} id - Mapping ID
+ * @property {string} project_id - Project ID
+ * @property {string} bill_title - Bill title to match
+ * @property {number|null} category_id - Category to assign
+ * @property {number} last_changed - Unix timestamp of last modification
+ * @property {number} created_at - Unix timestamp of creation
+ */
+
+/**
+ * @typedef {object} CopyImportResult
+ * @property {number} imported - Number of mappings imported
+ * @property {number} skipped - Number of mappings skipped
+ * @property {string[]} errors - Detailed skip reasons
+ */

--- a/src/utils.js
+++ b/src/utils.js
@@ -453,3 +453,28 @@ export function slugify(text) {
 		.replace(/^-+/, '') // trim - from start of text
 		.replace(/-+$/, '')
 }
+
+/**
+ * Extract a user-friendly error message from an API error response
+ *
+ * @param {Error} error - The error object from a failed request
+ * @param {string} fallback - Default message if no details are available
+ * @return {string} A user-friendly error message
+ */
+export function getErrorMessage(error, fallback) {
+	if (error?.response?.data?.ocs?.meta?.message) {
+		return error.response.data.ocs.meta.message
+	}
+	if (error?.response?.data?.ocs?.data?.message) {
+		return error.response.data.ocs.data.message
+	}
+	if (error?.message) {
+		return error.message
+	}
+	return fallback
+}
+
+export function decodeHtmlEntities(text) {
+	const parser = new DOMParser()
+	return parser.parseFromString(text, 'text/html').body.textContent || text
+}

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -20,35 +20,63 @@
 					@update:model-value="saveBalancePastBillsOnly">
 					{{ t('cospend', 'Only consider past bills to compute balances') }}
 				</NcFormBoxSwitch>
+				<NcFormBoxSwitch :model-value="state.auto_categorization_enabled"
+					:disabled="loading"
+					@update:model-value="saveAutoCategorizationEnabled">
+					{{ t('cospend', 'Enable auto-categorisation of bills') }}
+				</NcFormBoxSwitch>
+				<p v-if="state.auto_categorization_enabled" class="auto-cat-help-text">
+					{{ t('cospend', 'When enabled, bill titles are checked against per-project mappings on blur. Each project also has its own toggle to opt in or out.') }}
+				</p>
 			</NcFormBox>
+			<NcButton
+				v-if="state.auto_categorization_enabled"
+				class="auto-categorize-all-btn"
+				:disabled="autoCategorizingAll"
+				@click="onAutoCategorizeAll">
+				<template #icon>
+					<NcLoadingIcon v-if="autoCategorizingAll" />
+					<AutoFixIcon v-else :size="20" />
+				</template>
+				{{ t('cospend', 'Auto-categorise all existing bills') }}
+			</NcButton>
 		</div>
 	</div>
 </template>
 
 <script>
 import CospendIcon from '../components/icons/CospendIcon.vue'
+import AutoFixIcon from 'vue-material-design-icons/AutoFix.vue'
 
 import NcFormBoxSwitch from '@nextcloud/vue/components/NcFormBoxSwitch'
 import NcFormBox from '@nextcloud/vue/components/NcFormBox'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
-import { showError } from '@nextcloud/dialogs'
+import { showSuccess, showError } from '@nextcloud/dialogs'
+import { getErrorMessage } from '../utils.js'
+import * as network from '../network.js'
 
 export default {
 	name: 'AdminSettings',
 
 	components: {
 		CospendIcon,
+		AutoFixIcon,
 		NcFormBox,
 		NcFormBoxSwitch,
+		NcButton,
+		NcLoadingIcon,
 	},
 
 	data() {
 		return {
 			state: loadState('cospend', 'admin-settings', {}),
 			loading: false,
+			autoCategorizingAll: false,
 		}
 	},
 
@@ -87,6 +115,22 @@ export default {
 			this.state.balance_past_bills_only = value
 			this.saveOptions({ balance_past_bills_only: value ? '1' : '0' })
 		},
+		saveAutoCategorizationEnabled(value) {
+			this.state.auto_categorization_enabled = value
+			this.saveOptions({ auto_categorization_enabled: value ? '1' : '0' })
+		},
+		onAutoCategorizeAll() {
+			this.autoCategorizingAll = true
+			network.autoCategorizeAll().then((response) => {
+				const count = response.data.ocs.data
+				showSuccess(t('cospend', '{count} bill(s) categorised', { count }))
+			}).catch((error) => {
+				console.error('Failed to auto-categorize all', error)
+				showError(getErrorMessage(error, t('cospend', 'Failed to auto-categorise all bills')))
+			}).then(() => {
+				this.autoCategorizingAll = false
+			})
+		},
 	},
 }
 </script>
@@ -105,6 +149,17 @@ export default {
 		.icon {
 			margin-right: 8px;
 		}
+	}
+
+	.auto-categorize-all-btn {
+		margin-top: 12px;
+	}
+
+	.auto-cat-help-text {
+		color: var(--color-text-lighter);
+		font-size: 0.9em;
+		padding: 4px 0 0 40px;
+		margin: 0;
 	}
 }
 </style>

--- a/tests/php/service/AutoCategoryMappingsTest.php
+++ b/tests/php/service/AutoCategoryMappingsTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Cospend\Service;
+
+use OCA\Cospend\AppInfo\Application;
+use OCA\Cospend\Db\BillMapper;
+use OCA\Cospend\Exception\CospendBasicException;
+use OCP\AppFramework\Http;
+use OCP\IAppConfig;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the auto-categorisation feature (gh-402)
+ */
+class AutoCategoryMappingsTest extends TestCase {
+
+	private LocalProjectService $localProjectService;
+	private BillMapper $billMapper;
+	private IAppConfig $appConfig;
+	private int $memberId;
+	private int $groceriesCatId;
+	private int $fuelCatId;
+
+	public static function setUpBeforeClass(): void {
+		$app = new Application();
+		$c = $app->getContainer();
+
+		$userManager = $c->get(IUserManager::class);
+		if ($userManager->get('testautocat') === null) {
+			$userManager->createUser('testautocat', 'T0T0T0AutoCat!');
+		}
+	}
+
+	public static function tearDownAfterClass(): void {
+		$app = new Application();
+		$c = $app->getContainer();
+		$userManager = $c->get(IUserManager::class);
+		$user = $userManager->get('testautocat');
+		if ($user !== null) {
+			$user->delete();
+		}
+	}
+
+	protected function setUp(): void {
+		$app = new Application();
+		$c = $app->getContainer();
+		$this->billMapper = $c->get(BillMapper::class);
+		$this->localProjectService = $c->get(LocalProjectService::class);
+		$this->appConfig = $c->get(IAppConfig::class);
+
+		$this->deleteTestProjects();
+		$this->appConfig->setValueString(Application::APP_ID, 'auto_categorization_enabled', '1', lazy: true);
+
+		$this->localProjectService->createProject('AutoCat', 'autocatproj', null, 'testautocat');
+		$member = $this->localProjectService->createMember('autocatproj', 'bobby');
+		$this->memberId = $member['id'];
+		$this->groceriesCatId = $this->localProjectService->createCategory('autocatproj', 'Groceries', '🛒', '#00ff00');
+		$this->fuelCatId = $this->localProjectService->createCategory('autocatproj', 'Fuel', '⛽', '#ff0000');
+	}
+
+	protected function tearDown(): void {
+		$this->deleteTestProjects();
+		$this->appConfig->setValueString(Application::APP_ID, 'auto_categorization_enabled', '1', lazy: true);
+	}
+
+	private function deleteTestProjects(): void {
+		foreach (['autocatproj', 'autocattarget'] as $projId) {
+			try {
+				$this->localProjectService->deleteProject($projId);
+			} catch (\Throwable $t) {
+			}
+		}
+	}
+
+	private function createBill(string $what, ?int $categoryId = null, bool $autoCategorise = true): int {
+		return $this->localProjectService->createBill(
+			'autocatproj', null, $what, $this->memberId, (string)$this->memberId, 10.0,
+			'n', null, null, $categoryId, 0, null, 1700000000, null, null, 0, false, $autoCategorise
+		);
+	}
+
+	public function testMappingCrud() {
+		$mappingId = $this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+		$this->assertGreaterThan(0, $mappingId);
+
+		$mappings = $this->localProjectService->getAutoCategoryMappings('autocatproj');
+		$this->assertCount(1, $mappings);
+		$this->assertEquals('Aldi', $mappings[0]['bill_title']);
+		$this->assertEquals($this->groceriesCatId, $mappings[0]['category_id']);
+
+		$edited = $this->localProjectService->editAutoCategoryMapping('autocatproj', $mappingId, 'Aldi Sued', $this->fuelCatId);
+		$this->assertEquals('Aldi Sued', $edited['bill_title']);
+		$this->assertEquals($this->fuelCatId, $edited['category_id']);
+
+		$this->localProjectService->deleteAutoCategoryMapping('autocatproj', $mappingId);
+		$this->assertCount(0, $this->localProjectService->getAutoCategoryMappings('autocatproj'));
+	}
+
+	public function testDuplicateMappingIsRejected() {
+		$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+		try {
+			$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->fuelCatId);
+			$this->fail('duplicate mapping should throw');
+		} catch (CospendBasicException $e) {
+			$this->assertEquals(Http::STATUS_CONFLICT, $e->getCode());
+		}
+		// the duplicate check is case-insensitive
+		try {
+			$this->localProjectService->createAutoCategoryMapping('autocatproj', 'ALDI', $this->fuelCatId);
+			$this->fail('case-variant duplicate mapping should throw');
+		} catch (CospendBasicException $e) {
+			$this->assertEquals(Http::STATUS_CONFLICT, $e->getCode());
+		}
+	}
+
+	public function testEditMappingDuplicateAndNotFound() {
+		$mappingId1 = $this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+		$mappingId2 = $this->localProjectService->createAutoCategoryMapping('autocatproj', 'Shell', $this->fuelCatId);
+
+		// editing a mapping into a case-variant of another one is rejected
+		try {
+			$this->localProjectService->editAutoCategoryMapping('autocatproj', $mappingId2, 'aldi', $this->fuelCatId);
+			$this->fail('case-variant duplicate edit should throw');
+		} catch (CospendBasicException $e) {
+			$this->assertEquals(Http::STATUS_CONFLICT, $e->getCode());
+		}
+
+		// changing only the case of a mapping's own title is fine
+		$edited = $this->localProjectService->editAutoCategoryMapping('autocatproj', $mappingId1, 'ALDI', $this->groceriesCatId);
+		$this->assertEquals('ALDI', $edited['bill_title']);
+
+		try {
+			$this->localProjectService->editAutoCategoryMapping('autocatproj', 12345678, 'Lidl', $this->groceriesCatId);
+			$this->fail('editing an unknown mapping should throw');
+		} catch (CospendBasicException $e) {
+			$this->assertEquals(Http::STATUS_NOT_FOUND, $e->getCode());
+		}
+	}
+
+	public function testAutoCategorizeBillLookup() {
+		$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+
+		// lookup is case-insensitive
+		$this->assertEquals($this->groceriesCatId, $this->localProjectService->autoCategorizeBill('autocatproj', 'aldi'));
+		$this->assertEquals($this->groceriesCatId, $this->localProjectService->autoCategorizeBill('autocatproj', 'ALDI'));
+		$this->assertNull($this->localProjectService->autoCategorizeBill('autocatproj', 'Lidl'));
+		$this->assertNull($this->localProjectService->autoCategorizeBill('autocatproj', ''));
+	}
+
+	public function testBillCreationIsAutoCategorized() {
+		$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+
+		$billId = $this->createBill('ALDI');
+		$this->assertEquals($this->groceriesCatId, $this->billMapper->find($billId)->getCategoryId());
+
+		// opt-out is honored
+		$billId = $this->createBill('aldi', null, false);
+		$this->assertEquals(0, $this->billMapper->find($billId)->getCategoryId());
+
+		// an explicitly provided category wins over the mapping
+		$billId = $this->createBill('Aldi', $this->fuelCatId);
+		$this->assertEquals($this->fuelCatId, $this->billMapper->find($billId)->getCategoryId());
+
+		// no mapping, no category
+		$billId = $this->createBill('Lidl');
+		$this->assertEquals(0, $this->billMapper->find($billId)->getCategoryId());
+	}
+
+	public function testBillEditionIsAutoCategorized() {
+		$billId = $this->createBill('Aldi');
+		$this->assertEquals(0, $this->billMapper->find($billId)->getCategoryId());
+
+		$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+		$this->localProjectService->editBill(
+			'autocatproj', $billId, null, null, null, null, null, 'n',
+			null, null, null, null, null, null, 'edited comment'
+		);
+		$this->assertEquals($this->groceriesCatId, $this->billMapper->find($billId)->getCategoryId());
+	}
+
+	public function testTogglesDisableAutoCategorization() {
+		$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+
+		// per-project toggle
+		$this->localProjectService->editProject('autocatproj', null, null, null, null, null, null, null, null, '0');
+		$billId = $this->createBill('Aldi');
+		$this->assertEquals(0, $this->billMapper->find($billId)->getCategoryId());
+		$this->localProjectService->editProject('autocatproj', null, null, null, null, null, null, null, null, '1');
+
+		// global toggle
+		$this->appConfig->setValueString(Application::APP_ID, 'auto_categorization_enabled', '0', lazy: true);
+		$billId = $this->createBill('Aldi');
+		$this->assertEquals(0, $this->billMapper->find($billId)->getCategoryId());
+		$this->appConfig->setValueString(Application::APP_ID, 'auto_categorization_enabled', '1', lazy: true);
+
+		$billId = $this->createBill('Aldi');
+		$this->assertEquals($this->groceriesCatId, $this->billMapper->find($billId)->getCategoryId());
+	}
+
+	public function testRetroactiveAutoCategorization() {
+		$billId1 = $this->createBill('Aldi');
+		$billId2 = $this->createBill('aldi');
+		$billId3 = $this->createBill('Shell');
+		$categorizedBillId = $this->createBill('Aldi', $this->fuelCatId);
+
+		$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+		$count = $this->localProjectService->autoCategorizeProjectBills('autocatproj');
+		$this->assertEquals(2, $count);
+
+		$this->assertEquals($this->groceriesCatId, $this->billMapper->find($billId1)->getCategoryId());
+		$this->assertEquals($this->groceriesCatId, $this->billMapper->find($billId2)->getCategoryId());
+		$this->assertEquals(0, $this->billMapper->find($billId3)->getCategoryId());
+		// already categorized bills are left alone
+		$this->assertEquals($this->fuelCatId, $this->billMapper->find($categorizedBillId)->getCategoryId());
+	}
+
+	public function testCategoryDeletionNullifiesMappings() {
+		$mappingId = $this->localProjectService->createAutoCategoryMapping('autocatproj', 'Shell', $this->fuelCatId);
+		$this->localProjectService->deleteCategory('autocatproj', $this->fuelCatId);
+
+		$mappings = $this->localProjectService->getAutoCategoryMappings('autocatproj');
+		$this->assertCount(1, $mappings);
+		$this->assertEquals($mappingId, $mappings[0]['id']);
+		$this->assertNull($mappings[0]['category_id']);
+
+		// a nullified mapping does not categorize anything
+		$this->assertNull($this->localProjectService->autoCategorizeBill('autocatproj', 'Shell'));
+	}
+
+	public function testCopyMappings() {
+		$this->localProjectService->createProject('AutoCatTarget', 'autocattarget', null, 'testautocat');
+		$targetGroceriesCatId = $this->localProjectService->createCategory('autocattarget', 'groceries', '🛒', '#00ff00');
+
+		$aldiMappingId = $this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+		$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Shell', $this->fuelCatId);
+
+		// Groceries matches by name (case-insensitive), Fuel does not exist in the target
+		$result = $this->localProjectService->copyAutoCategoryMappings('autocatproj', 'autocattarget');
+		$this->assertEquals(1, $result['imported']);
+		$this->assertEquals(1, $result['skipped']);
+		$this->assertCount(1, $result['errors']);
+
+		$targetMappings = $this->localProjectService->getAutoCategoryMappings('autocattarget');
+		$this->assertCount(1, $targetMappings);
+		$this->assertEquals('Aldi', $targetMappings[0]['bill_title']);
+		$this->assertEquals($targetGroceriesCatId, $targetMappings[0]['category_id']);
+
+		// copying again skips the existing mapping
+		$result = $this->localProjectService->copyAutoCategoryMappings('autocatproj', 'autocattarget');
+		$this->assertEquals(0, $result['imported']);
+		$this->assertEquals(2, $result['skipped']);
+
+		// single-mapping copy of an already existing mapping
+		$result = $this->localProjectService->copyAutoCategoryMappings('autocatproj', 'autocattarget', $aldiMappingId);
+		$this->assertEquals(0, $result['imported']);
+		$this->assertEquals(1, $result['skipped']);
+
+		// single-mapping copy with an unknown id
+		try {
+			$this->localProjectService->copyAutoCategoryMappings('autocatproj', 'autocattarget', 12345678);
+			$this->fail('copying an unknown mapping should throw');
+		} catch (CospendBasicException $e) {
+			$this->assertEquals(Http::STATUS_NOT_FOUND, $e->getCode());
+		}
+	}
+
+	public function testProjectDeletionRemovesMappings() {
+		$this->localProjectService->createAutoCategoryMapping('autocatproj', 'Aldi', $this->groceriesCatId);
+		$this->assertCount(1, $this->localProjectService->getAutoCategoryMappings('autocatproj'));
+
+		$this->localProjectService->deleteProject('autocatproj');
+		$this->assertCount(0, $this->localProjectService->getAutoCategoryMappings('autocatproj'));
+	}
+}


### PR DESCRIPTION
Addresses #402

Will test on personal prod before sending a PR to upstream.

Bills that are created or edited **without a category** get one assigned automatically when their title matches one of the project's title → category mappings (like Splitwise does). Matching is case-insensitive on the exact title.

## How it works

- **Bill form**: when typing a bill title that matches a mapping, the category is filled in on blur. When the user picks a category manually, a checkbox offers to save (or update) the title → category pair as a mapping, so mappings are mostly created as a side effect of normal use.
- **Server side**: `createBill`/`editBill` apply the mapping whenever no category is given and the bill is uncategorised. This includes the public API, so clients like MoneyBuster benefit without changes. API clients can opt out per call with `autoCategorise=false`.
- **Management UI**: in the *Categories* tab of the project sidebar (below the category list): add/edit/delete mappings, apply them retroactively to existing uncategorised bills, and copy/import mappings between projects (categories are matched by name there, since category ids are per-project).
- **Toggles**: per-project toggle in the project settings (default on), instance-wide toggle in the admin settings (default on). Two occ commands allow retroactive categorisation of one or all projects.

## Permissions

- reading mappings: viewer (needed for the bill-form behaviour)
- creating/editing/deleting mappings, retroactive apply: maintainer
- copying mappings to another project additionally requires maintainer access on the target project; importing requires at least viewer access on the source project

## Database

One migration: a `cospend_auto_category_mappings` table (unique on project + title) and an `auto_categorization` column on `cospend_projects` for the per-project toggle. Deleting a category
clears it from its mappings (they are kept and flagged in the UI), deleting a project deletes its mappings.

## Scope notes / open questions

- There is **no public (share link) API for managing mappings** — bills created via share links are still auto-categorised server-side, but the management UI is hidden on public pages. Happy to add public endpoints for parity with categories if you want them.
- The management UI lives in the *Categories* sidebar tab since mappings are category configuration. Easy to move if you'd prefer it elsewhere.

## Testing

- integration tests in `tests/php/service/AutoCategoryMappingsTest.php` (mapping CRUD, duplicate handling, categorisation on create/edit and opt-out, both toggles, retroactive apply, category deletion, copy between projects, project deletion cleanup)
- manually tested against NC 33 (desktop + mobile widths, public link sessions, second user for the permission checks)

## Screenshots

Bill form:
 <img width="1815" height="1244" alt="image" src="https://github.com/user-attachments/assets/e94cfe1f-40dd-406b-a9ea-910863b23081" />

Mapping Management:
<img width="611" height="1215" alt="image" src="https://github.com/user-attachments/assets/a8447439-ca11-4730-9e04-d54fc1c99ab9" />

<img width="605" height="245" alt="image" src="https://github.com/user-attachments/assets/be203fd7-cc50-4e91-8c40-af65cfdc77ec" />
<img width="585" height="400" alt="image" src="https://github.com/user-attachments/assets/99bcd52d-8c3d-42aa-b682-386bc11e79de" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)